### PR TITLE
[Featuer] 카테고리 리스트 조회 API

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,16 @@ jacocoTestReport {
         html.enabled true
         // 기본 경로는 build/reports/jacoco
     }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, excludes: [
+                    "**/*Application*",
+                    "**/config*/*",
+                    "**/*Swagger*",
+            ])
+        }))
+    }
 }
 
 tasks.jacocoTestCoverageVerification {
@@ -71,6 +81,12 @@ tasks.jacocoTestCoverageVerification {
                 value = "COVEREDRATIO"
                 minimum = "0.80".toBigDecimal()
             }
+
+            excludes = [
+                    "**/*Application*",
+                    "**/config*/*",
+                    "**/*Swagger*",
+            ]
         }
     }
 }

--- a/src/main/java/com/pororoz/istock/common/swagger/exception/AccessForbiddenSwagger.java
+++ b/src/main/java/com/pororoz/istock/common/swagger/exception/AccessForbiddenSwagger.java
@@ -1,0 +1,15 @@
+package com.pororoz.istock.common.swagger.exception;
+
+import com.pororoz.istock.common.utils.message.ExceptionMessage;
+import com.pororoz.istock.common.utils.message.ExceptionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class AccessForbiddenSwagger {
+  @Schema(description = "에러 명칭", example = ExceptionStatus.FORBIDDEN)
+  private String status;
+
+  @Schema(description = "상세 메시지", example = ExceptionMessage.FORBIDDEN)
+  private String message;
+}

--- a/src/main/java/com/pororoz/istock/common/swagger/exception/InvalidPageRequestExceptionSwagger.java
+++ b/src/main/java/com/pororoz/istock/common/swagger/exception/InvalidPageRequestExceptionSwagger.java
@@ -1,0 +1,15 @@
+package com.pororoz.istock.common.swagger.exception;
+
+import com.pororoz.istock.common.utils.message.ExceptionMessage;
+import com.pororoz.istock.common.utils.message.ExceptionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class InvalidPageRequestExceptionSwagger {
+  @Schema(description = "에러 명칭", example = ExceptionStatus.BAD_REQUEST)
+  private String status;
+
+  @Schema(description = "상세 메시지", example = ExceptionMessage.INVALID_PAGE_REQUEST)
+  private String message;
+}

--- a/src/main/java/com/pororoz/istock/common/utils/message/ExceptionMessage.java
+++ b/src/main/java/com/pororoz/istock/common/utils/message/ExceptionMessage.java
@@ -14,6 +14,7 @@ public class ExceptionMessage {
   public static final String INTERNAL_SERVER_ERROR = "내부 서버 오류입니다.";
   public static final String INVALID_PAGE_REQUEST = "page는 0 이상, size는 1 이상을 입력해주세요.";
   public static final String INVALID_CATEGORY_NAME = "카테고리는 2자 이상, 15자 이하로 입력해주세요.";
+  public static final String FORBIDDEN = "사용이 거절되었습니다.";
 
   private ExceptionMessage() {
   }

--- a/src/main/java/com/pororoz/istock/common/utils/message/ExceptionStatus.java
+++ b/src/main/java/com/pororoz/istock/common/utils/message/ExceptionStatus.java
@@ -12,7 +12,7 @@ public class ExceptionStatus {
   // Uncontrolled Range
   public static final String RUNTIME_ERROR = "RUNTIME_ERROR";
   public static final String INTERNAL_SERVER_ERROR = "INTERNAL_SERVER_ERROR";
-
+  public static final String FORBIDDEN = "FORBIDDEN";
 
   private ExceptionStatus() {
   }

--- a/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
@@ -56,7 +56,7 @@ public class CategoryController {
         FindCategoryServiceResponse::toResponse);
     PageResponse<FindCategoryResponse> response = new PageResponse<>(categoryPage);
     return ResponseEntity.ok(
-        new ResultDTO<>(ResponseStatus.OK, ResponseMessage.FIND_USER, response));
+        new ResultDTO<>(ResponseStatus.OK, "", response));
   }
 
   @Operation(summary = "save category", description = "카테고리 생성 API")

--- a/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
@@ -15,6 +15,7 @@ import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRespons
 import com.pororoz.istock.domain.category.service.CategoryService;
 import com.pororoz.istock.domain.category.swagger.exception.InternalServerErrorExceptionSwagger;
 import com.pororoz.istock.domain.category.swagger.response.DeleteCategoryResponseSwagger;
+import com.pororoz.istock.domain.category.swagger.response.FindCategoryResponseSwagger;
 import com.pororoz.istock.domain.category.swagger.response.SaveCategoryResponseSwagger;
 import com.pororoz.istock.domain.user.swagger.exception.InvalidPathExceptionSwagger;
 import io.swagger.v3.oas.annotations.Operation;
@@ -48,6 +49,11 @@ public class CategoryController {
 
   private final CategoryService categoryService;
 
+  @Operation(summary = "find category", description = "카테고리 리스트 조회 API")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200",
+          content = {@Content(schema = @Schema(implementation = FindCategoryResponseSwagger.class))}),
+  })
   @GetMapping
   public ResponseEntity<ResultDTO<PageResponse<FindCategoryResponse>>> findCategories(
       @ModelAttribute("request") FindCategoryRequest request

--- a/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
@@ -1,13 +1,17 @@
 package com.pororoz.istock.domain.category.controller;
 
+import com.pororoz.istock.common.dto.PageResponse;
 import com.pororoz.istock.common.dto.ResultDTO;
 import com.pororoz.istock.common.utils.message.ExceptionMessage;
 import com.pororoz.istock.common.utils.message.ResponseMessage;
 import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.category.dto.request.FindCategoryRequest;
 import com.pororoz.istock.domain.category.dto.request.SaveCategoryRequest;
 import com.pororoz.istock.domain.category.dto.response.CategoryResponse;
+import com.pororoz.istock.domain.category.dto.response.FindCategoryResponse;
 import com.pororoz.istock.domain.category.dto.service.CategoryServiceResponse;
 import com.pororoz.istock.domain.category.dto.service.DeleteCategoryServiceRequest;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceResponse;
 import com.pororoz.istock.domain.category.service.CategoryService;
 import com.pororoz.istock.domain.category.swagger.exception.InternalServerErrorExceptionSwagger;
 import com.pororoz.istock.domain.category.swagger.response.DeleteCategoryResponseSwagger;
@@ -23,9 +27,17 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Category", description = "Category API")
 @RestController
@@ -35,6 +47,17 @@ import org.springframework.web.bind.annotation.*;
 public class CategoryController {
 
   private final CategoryService categoryService;
+
+  @GetMapping
+  public ResponseEntity<ResultDTO<PageResponse<FindCategoryResponse>>> findCategories(
+      @ModelAttribute("request") FindCategoryRequest request
+  ) {
+    Page<FindCategoryResponse> categoryPage = categoryService.findCategories(request.toService()).map(
+        FindCategoryServiceResponse::toResponse);
+    PageResponse<FindCategoryResponse> response = new PageResponse<>(categoryPage);
+    return ResponseEntity.ok(
+        new ResultDTO<>(ResponseStatus.OK, ResponseMessage.FIND_USER, response));
+  }
 
   @Operation(summary = "save category", description = "카테고리 생성 API")
   @ApiResponses({

--- a/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/pororoz/istock/domain/category/controller/CategoryController.java
@@ -2,6 +2,7 @@ package com.pororoz.istock.domain.category.controller;
 
 import com.pororoz.istock.common.dto.PageResponse;
 import com.pororoz.istock.common.dto.ResultDTO;
+import com.pororoz.istock.common.swagger.exception.AccessForbiddenSwagger;
 import com.pororoz.istock.common.utils.message.ExceptionMessage;
 import com.pororoz.istock.common.utils.message.ResponseMessage;
 import com.pororoz.istock.common.utils.message.ResponseStatus;
@@ -16,6 +17,7 @@ import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRespons
 import com.pororoz.istock.domain.category.service.CategoryService;
 import com.pororoz.istock.domain.category.swagger.exception.CategoryNotFoundExceptionSwagger;
 import com.pororoz.istock.domain.category.swagger.exception.InternalServerErrorExceptionSwagger;
+import com.pororoz.istock.common.swagger.exception.InvalidPageRequestExceptionSwagger;
 import com.pororoz.istock.domain.category.swagger.response.DeleteCategoryResponseSwagger;
 import com.pororoz.istock.domain.category.swagger.response.FindCategoryResponseSwagger;
 import com.pororoz.istock.domain.category.swagger.response.SaveCategoryResponseSwagger;
@@ -56,14 +58,22 @@ public class CategoryController {
   @Operation(summary = "find category", description = "카테고리 리스트 조회 API")
   @ApiResponses({
       @ApiResponse(responseCode = "200",
-          content = {@Content(schema = @Schema(implementation = FindCategoryResponseSwagger.class))}),
+          content = {
+              @Content(schema = @Schema(implementation = FindCategoryResponseSwagger.class))}),
+      @ApiResponse(responseCode = "400", description = ExceptionMessage.INTERNAL_SERVER_ERROR,
+          content = {
+              @Content(schema = @Schema(implementation = InvalidPageRequestExceptionSwagger.class))}),
+      @ApiResponse(responseCode = "403", description = ExceptionMessage.FORBIDDEN,
+          content = {
+              @Content(schema = @Schema(implementation = AccessForbiddenSwagger.class))})
   })
   @GetMapping
   public ResponseEntity<ResultDTO<PageResponse<FindCategoryResponse>>> findCategories(
-      @ModelAttribute("request") FindCategoryRequest request
+      @Valid @ModelAttribute("request") FindCategoryRequest request
   ) {
-    Page<FindCategoryResponse> categoryPage = categoryService.findCategories(request.toService()).map(
-        FindCategoryServiceResponse::toResponse);
+    Page<FindCategoryResponse> categoryPage = categoryService.findCategories(request.toService())
+        .map(
+            FindCategoryServiceResponse::toResponse);
     PageResponse<FindCategoryResponse> response = new PageResponse<>(categoryPage);
     return ResponseEntity.ok(
         new ResultDTO<>(ResponseStatus.OK, "", response));
@@ -76,7 +86,10 @@ public class CategoryController {
               @Content(schema = @Schema(implementation = SaveCategoryResponseSwagger.class))}),
       @ApiResponse(responseCode = "400", description = ExceptionMessage.INTERNAL_SERVER_ERROR,
           content = {
-              @Content(schema = @Schema(implementation = InternalServerErrorExceptionSwagger.class))})
+              @Content(schema = @Schema(implementation = InternalServerErrorExceptionSwagger.class))}),
+      @ApiResponse(responseCode = "403", description = ExceptionMessage.FORBIDDEN,
+          content = {
+              @Content(schema = @Schema(implementation = AccessForbiddenSwagger.class))})
   })
   @PostMapping
   public ResponseEntity<ResultDTO<CategoryResponse>> saveCategory(
@@ -92,8 +105,12 @@ public class CategoryController {
   @ApiResponses({
       @ApiResponse(responseCode = "200", description = ResponseMessage.UPDATE_CATEGORY, content = {
           @Content(schema = @Schema(implementation = UpdateCategoryResponseSwagger.class))}),
+      @ApiResponse(responseCode = "403", description = ExceptionMessage.FORBIDDEN,
+          content = {
+              @Content(schema = @Schema(implementation = AccessForbiddenSwagger.class))}),
       @ApiResponse(responseCode = "404", description = ExceptionMessage.CATEGORY_NOT_FOUND, content = {
-          @Content(schema = @Schema(implementation = CategoryNotFoundExceptionSwagger.class))}),})
+          @Content(schema = @Schema(implementation = CategoryNotFoundExceptionSwagger.class))}),
+  })
   @PutMapping
   public ResponseEntity<ResultDTO<CategoryResponse>> updateCategory(
       @Valid @RequestBody UpdateCategoryRequest request) {
@@ -111,6 +128,9 @@ public class CategoryController {
       @ApiResponse(responseCode = "400", description = ExceptionMessage.INVALID_PATH,
           content = {
               @Content(schema = @Schema(implementation = InvalidPathExceptionSwagger.class))}),
+      @ApiResponse(responseCode = "403", description = ExceptionMessage.FORBIDDEN,
+          content = {
+              @Content(schema = @Schema(implementation = AccessForbiddenSwagger.class))})
   })
   @DeleteMapping("/{id}")
   public ResponseEntity<ResultDTO<CategoryResponse>> deleteCategory(

--- a/src/main/java/com/pororoz/istock/domain/category/dto/request/FindCategoryRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/request/FindCategoryRequest.java
@@ -2,6 +2,7 @@ package com.pororoz.istock.domain.category.dto.request;
 
 import com.pororoz.istock.common.utils.message.ExceptionMessage;
 import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.annotation.Nullable;
 import jakarta.validation.constraints.Positive;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -12,13 +13,16 @@ import lombok.Getter;
 @Builder
 public class FindCategoryRequest {
 
+  @Schema(description = "카테고리 이름", example = "착화기")
   @Nullable
   private String query;
 
+  @Schema(description = "페이지 요청", example = "0")
   @Nullable
   @PositiveOrZero(message = ExceptionMessage.INVALID_PAGE_REQUEST)
   private Integer page;
 
+  @Schema(description = "사이즈 요청", example = "20")
   @Nullable
   @Positive(message = ExceptionMessage.INVALID_PAGE_REQUEST)
   private Integer size;

--- a/src/main/java/com/pororoz/istock/domain/category/dto/request/FindCategoryRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/request/FindCategoryRequest.java
@@ -1,0 +1,29 @@
+package com.pororoz.istock.domain.category.dto.request;
+
+import com.pororoz.istock.common.utils.message.ExceptionMessage;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRequest;
+import jakarta.annotation.Nullable;
+import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindCategoryRequest {
+
+  @Nullable
+  private String name;
+
+  @Nullable
+  @PositiveOrZero(message = ExceptionMessage.INVALID_PAGE_REQUEST)
+  private Integer page;
+
+  @Nullable
+  @Positive(message = ExceptionMessage.INVALID_PAGE_REQUEST)
+  private Integer size;
+
+  public FindCategoryServiceRequest toService() {
+    return FindCategoryServiceRequest.builder().name(name).page(page).size(size).build();
+  }
+}

--- a/src/main/java/com/pororoz/istock/domain/category/dto/request/FindCategoryRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/request/FindCategoryRequest.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 public class FindCategoryRequest {
 
   @Nullable
-  private String name;
+  private String query;
 
   @Nullable
   @PositiveOrZero(message = ExceptionMessage.INVALID_PAGE_REQUEST)
@@ -24,6 +24,6 @@ public class FindCategoryRequest {
   private Integer size;
 
   public FindCategoryServiceRequest toService() {
-    return FindCategoryServiceRequest.builder().name(name).page(page).size(size).build();
+    return FindCategoryServiceRequest.builder().name(query).page(page).size(size).build();
   }
 }

--- a/src/main/java/com/pororoz/istock/domain/category/dto/response/CategoryResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/response/CategoryResponse.java
@@ -1,11 +1,11 @@
 package com.pororoz.istock.domain.category.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.Builder;
 import lombok.Getter;
+import lombok.experimental.SuperBuilder;
 
 @Getter
-@Builder
+@SuperBuilder
 public class CategoryResponse {
 
   @Schema(description = "카테고리 아이디", example = "1")
@@ -14,4 +14,20 @@ public class CategoryResponse {
   @Schema(description = "카테고리 이름", example = "착화기")
   private String name;
 
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    if (!super.equals(obj)) {
+      return false;
+    }
+
+    CategoryResponse response = (CategoryResponse) obj;
+    return id.equals(response.getId()) &&
+        name.equals(response.getName());
+  }
 }

--- a/src/main/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponse.java
@@ -1,5 +1,6 @@
 package com.pororoz.istock.domain.category.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.Objects;
 import lombok.Getter;
 import lombok.experimental.SuperBuilder;
@@ -8,8 +9,10 @@ import lombok.experimental.SuperBuilder;
 @SuperBuilder
 public class FindCategoryResponse extends CategoryResponse{
 
+  @Schema(description = "생성 시간", example = "2023-01-01 00:00:00")
   private String createdAt;
 
+  @Schema(description = "수정 시간", example = "2023-01-01 00:00:00")
   private String updatedAt;
 
   @Override

--- a/src/main/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponse.java
@@ -1,0 +1,36 @@
+package com.pororoz.istock.domain.category.dto.response;
+
+import java.util.Objects;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@Getter
+@SuperBuilder
+public class FindCategoryResponse extends CategoryResponse{
+
+  private String createdAt;
+
+  private String updatedAt;
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    if (!super.equals(obj)) {
+      return false;
+    }
+
+    FindCategoryResponse that = (FindCategoryResponse) obj;
+    return super.getId().equals(that.getId()) && super.getName().equals(that.getName()) &&
+        Objects.equals(createdAt, that.createdAt) && Objects.equals(updatedAt, that.updatedAt);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.getId(), super.getName(), createdAt, updatedAt);
+  }
+}

--- a/src/main/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponse.java
@@ -20,9 +20,6 @@ public class FindCategoryResponse extends CategoryResponse{
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    if (!super.equals(obj)) {
-      return false;
-    }
 
     FindCategoryResponse that = (FindCategoryResponse) obj;
     return super.getId().equals(that.getId()) && super.getName().equals(that.getName()) &&

--- a/src/main/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceRequest.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.PageRequest;
 
 @Getter
 @Builder
-public class GetCategoryServiceRequest {
+public class FindCategoryServiceRequest {
 
   public static final int DEFAULT_PAGE = 0;
   public static final int DEFAULT_SIZE = 20;

--- a/src/main/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceResponse.java
@@ -8,7 +8,7 @@ import lombok.Getter;
 
 @Getter
 @Builder
-public class GetCategoryServiceResponse {
+public class FindCategoryServiceResponse {
 
   private Long id;
 
@@ -18,8 +18,8 @@ public class GetCategoryServiceResponse {
 
   private LocalDateTime updatedAt;
 
-  public static GetCategoryServiceResponse of(Category category) {
-    return GetCategoryServiceResponse.builder().id(category.getId()).name(category.getName())
+  public static FindCategoryServiceResponse of(Category category) {
+    return FindCategoryServiceResponse.builder().id(category.getId()).name(category.getName())
         .createdAt(category.getCreatedAt()).updatedAt(category.getUpdatedAt()).build();
   }
 
@@ -31,7 +31,7 @@ public class GetCategoryServiceResponse {
     if (obj == null || getClass() != obj.getClass()) {
       return false;
     }
-    GetCategoryServiceResponse that = (GetCategoryServiceResponse) obj;
+    FindCategoryServiceResponse that = (FindCategoryServiceResponse) obj;
     return Objects.equals(id, that.id) && Objects.equals(name, that.name)
         && Objects.equals(createdAt, that.createdAt) && Objects.equals(updatedAt,
         that.updatedAt);

--- a/src/main/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceResponse.java
@@ -1,5 +1,7 @@
 package com.pororoz.istock.domain.category.dto.service;
 
+import com.pororoz.istock.common.entity.TimeEntity;
+import com.pororoz.istock.domain.category.dto.response.FindCategoryResponse;
 import com.pororoz.istock.domain.category.entity.Category;
 import java.time.LocalDateTime;
 import java.util.Objects;
@@ -35,5 +37,19 @@ public class FindCategoryServiceResponse {
     return Objects.equals(id, that.id) && Objects.equals(name, that.name)
         && Objects.equals(createdAt, that.createdAt) && Objects.equals(updatedAt,
         that.updatedAt);
+  }
+
+  public FindCategoryResponse toResponse() {
+    return FindCategoryResponse.builder()
+        .id(id)
+        .name(name)
+        .createdAt(TimeEntity.formatTime(createdAt))
+        .updatedAt(TimeEntity.formatTime(updatedAt))
+        .build();
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(id, name, createdAt, updatedAt);
   }
 }

--- a/src/main/java/com/pororoz/istock/domain/category/dto/service/GetCategoryServiceRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/service/GetCategoryServiceRequest.java
@@ -1,0 +1,25 @@
+package com.pororoz.istock.domain.category.dto.service;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.data.domain.PageRequest;
+
+@Getter
+@Builder
+public class GetCategoryServiceRequest {
+
+  public static final int DEFAULT_PAGE = 0;
+  public static final int DEFAULT_SIZE = 20;
+
+  private String name;
+
+  private Integer page;
+
+  private Integer size;
+
+  public PageRequest toPageRequest() {
+    return PageRequest.of(
+        page == null ? DEFAULT_PAGE : page,
+        size == null ? DEFAULT_SIZE : size);
+  }
+}

--- a/src/main/java/com/pororoz/istock/domain/category/dto/service/GetCategoryServiceResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/service/GetCategoryServiceResponse.java
@@ -1,0 +1,18 @@
+package com.pororoz.istock.domain.category.dto.service;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class GetCategoryServiceResponse {
+
+  private Long id;
+
+  private String name;
+
+  private LocalDateTime createdAt;
+
+  private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/pororoz/istock/domain/category/dto/service/GetCategoryServiceResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/category/dto/service/GetCategoryServiceResponse.java
@@ -1,6 +1,8 @@
 package com.pororoz.istock.domain.category.dto.service;
 
+import com.pororoz.istock.domain.category.entity.Category;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -15,4 +17,23 @@ public class GetCategoryServiceResponse {
   private LocalDateTime createdAt;
 
   private LocalDateTime updatedAt;
+
+  public static GetCategoryServiceResponse of(Category category) {
+    return GetCategoryServiceResponse.builder().id(category.getId()).name(category.getName())
+        .createdAt(category.getCreatedAt()).updatedAt(category.getUpdatedAt()).build();
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+    GetCategoryServiceResponse that = (GetCategoryServiceResponse) obj;
+    return Objects.equals(id, that.id) && Objects.equals(name, that.name)
+        && Objects.equals(createdAt, that.createdAt) && Objects.equals(updatedAt,
+        that.updatedAt);
+  }
 }

--- a/src/main/java/com/pororoz/istock/domain/category/entity/Category.java
+++ b/src/main/java/com/pororoz/istock/domain/category/entity/Category.java
@@ -3,10 +3,14 @@ package com.pororoz.istock.domain.category.entity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters.LocalDateTimeConverter;
 
 @Builder
 @AllArgsConstructor
@@ -24,5 +28,11 @@ public class Category {
   @Column(unique = true, nullable = false)
   private String name;
 
+  @CreatedDate
+  @Convert(converter = LocalDateTimeConverter.class)
+  private LocalDateTime createdAt;
 
+  @LastModifiedDate
+  @Convert(converter = LocalDateTimeConverter.class)
+  private LocalDateTime updatedAt;
 }

--- a/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
@@ -10,4 +10,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
   Page<Category> findAllByNameContaining(String name, Pageable pageable);
 
   List<Category> findAllByNameContaining(String name);
+
+  Page<Category> findAllByNameContaining(Pageable pageable);
 }

--- a/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
@@ -1,8 +1,10 @@
 package com.pororoz.istock.domain.category.repository;
 
 import com.pororoz.istock.domain.category.entity.Category;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-
+  PageImpl<Category> findAllByName(PageRequest pageRequest);
 }

--- a/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
@@ -1,15 +1,10 @@
 package com.pororoz.istock.domain.category.repository;
 
 import com.pororoz.istock.domain.category.entity.Category;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
   Page<Category> findAllByNameContaining(String name, Pageable pageable);
-
-  List<Category> findAllByNameContaining(String name);
-
-  Page<Category> findAllByNameContaining(Pageable pageable);
 }

--- a/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/pororoz/istock/domain/category/repository/CategoryRepository.java
@@ -1,10 +1,13 @@
 package com.pororoz.istock.domain.category.repository;
 
 import com.pororoz.istock.domain.category.entity.Category;
-import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
+import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-  PageImpl<Category> findAllByName(PageRequest pageRequest);
+  Page<Category> findAllByNameContaining(String name, Pageable pageable);
+
+  List<Category> findAllByNameContaining(String name);
 }

--- a/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
+++ b/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
@@ -8,10 +8,8 @@ import com.pororoz.istock.domain.category.dto.service.SaveCategoryServiceRequest
 import com.pororoz.istock.domain.category.entity.Category;
 import com.pororoz.istock.domain.category.exception.CategoryNotFoundException;
 import com.pororoz.istock.domain.category.repository.CategoryRepository;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -23,18 +21,8 @@ public class CategoryService {
   private final CategoryRepository categoryRepository;
 
   public Page<FindCategoryServiceResponse> findCategories(FindCategoryServiceRequest request) {
-    if (request.getPage() == null && request.getSize() == null) {
-      if (request.getName() == null) {
-        List<Category> categories = categoryRepository.findAll();
-        return new PageImpl<>(categories).map(FindCategoryServiceResponse::of);
-      }
-
-      List<Category> categories = categoryRepository.findAllByNameContaining(request.getName());
-      return new PageImpl<>(categories).map(FindCategoryServiceResponse::of);
-    }
-
     if (request.getName() == null) {
-      return categoryRepository.findAllByNameContaining(request.toPageRequest())
+      return categoryRepository.findAll(request.toPageRequest())
           .map(FindCategoryServiceResponse::of);
     }
 

--- a/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
+++ b/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
@@ -32,6 +32,12 @@ public class CategoryService {
       List<Category> categories = categoryRepository.findAllByNameContaining(request.getName());
       return new PageImpl<>(categories).map(GetCategoryServiceResponse::of);
     }
+
+    if (request.getName() == null) {
+      return categoryRepository.findAllByNameContaining(request.toPageRequest())
+          .map(GetCategoryServiceResponse::of);
+    }
+
     return categoryRepository.findAllByNameContaining(request.getName(), request.toPageRequest())
         .map(GetCategoryServiceResponse::of);
   }

--- a/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
+++ b/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
@@ -22,6 +22,7 @@ public class CategoryService {
 
   private final CategoryRepository categoryRepository;
 
+  @Transactional(readOnly=true)
   public Page<FindCategoryServiceResponse> findCategories(FindCategoryServiceRequest request) {
     if (request.getName() == null) {
       return categoryRepository.findAll(request.toPageRequest())

--- a/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
+++ b/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
@@ -1,13 +1,17 @@
 package com.pororoz.istock.domain.category.service;
 
-
 import com.pororoz.istock.domain.category.dto.service.CategoryServiceResponse;
 import com.pororoz.istock.domain.category.dto.service.DeleteCategoryServiceRequest;
+import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceRequest;
+import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceResponse;
 import com.pororoz.istock.domain.category.dto.service.SaveCategoryServiceRequest;
 import com.pororoz.istock.domain.category.entity.Category;
 import com.pororoz.istock.domain.category.exception.CategoryNotFoundException;
 import com.pororoz.istock.domain.category.repository.CategoryRepository;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +21,20 @@ import org.springframework.transaction.annotation.Transactional;
 public class CategoryService {
 
   private final CategoryRepository categoryRepository;
+
+  public Page<GetCategoryServiceResponse> findCategories(GetCategoryServiceRequest request) {
+    if (request.getPage() == null && request.getSize() == null) {
+      if (request.getName() == null) {
+        List<Category> categories = categoryRepository.findAll();
+        return new PageImpl<>(categories).map(GetCategoryServiceResponse::of);
+      }
+
+      List<Category> categories = categoryRepository.findAllByNameContaining(request.getName());
+      return new PageImpl<>(categories).map(GetCategoryServiceResponse::of);
+    }
+    return categoryRepository.findAllByNameContaining(request.getName(), request.toPageRequest())
+        .map(GetCategoryServiceResponse::of);
+  }
 
   public CategoryServiceResponse saveCategory(
       SaveCategoryServiceRequest saveCategoryServiceRequest) {

--- a/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
+++ b/src/main/java/com/pororoz/istock/domain/category/service/CategoryService.java
@@ -2,8 +2,8 @@ package com.pororoz.istock.domain.category.service;
 
 import com.pororoz.istock.domain.category.dto.service.CategoryServiceResponse;
 import com.pororoz.istock.domain.category.dto.service.DeleteCategoryServiceRequest;
-import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceRequest;
-import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceResponse;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRequest;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceResponse;
 import com.pororoz.istock.domain.category.dto.service.SaveCategoryServiceRequest;
 import com.pororoz.istock.domain.category.entity.Category;
 import com.pororoz.istock.domain.category.exception.CategoryNotFoundException;
@@ -22,24 +22,24 @@ public class CategoryService {
 
   private final CategoryRepository categoryRepository;
 
-  public Page<GetCategoryServiceResponse> findCategories(GetCategoryServiceRequest request) {
+  public Page<FindCategoryServiceResponse> findCategories(FindCategoryServiceRequest request) {
     if (request.getPage() == null && request.getSize() == null) {
       if (request.getName() == null) {
         List<Category> categories = categoryRepository.findAll();
-        return new PageImpl<>(categories).map(GetCategoryServiceResponse::of);
+        return new PageImpl<>(categories).map(FindCategoryServiceResponse::of);
       }
 
       List<Category> categories = categoryRepository.findAllByNameContaining(request.getName());
-      return new PageImpl<>(categories).map(GetCategoryServiceResponse::of);
+      return new PageImpl<>(categories).map(FindCategoryServiceResponse::of);
     }
 
     if (request.getName() == null) {
       return categoryRepository.findAllByNameContaining(request.toPageRequest())
-          .map(GetCategoryServiceResponse::of);
+          .map(FindCategoryServiceResponse::of);
     }
 
     return categoryRepository.findAllByNameContaining(request.getName(), request.toPageRequest())
-        .map(GetCategoryServiceResponse::of);
+        .map(FindCategoryServiceResponse::of);
   }
 
   public CategoryServiceResponse saveCategory(

--- a/src/main/java/com/pororoz/istock/domain/category/swagger/response/FindCategoryResponseSwagger.java
+++ b/src/main/java/com/pororoz/istock/domain/category/swagger/response/FindCategoryResponseSwagger.java
@@ -1,0 +1,21 @@
+package com.pororoz.istock.domain.category.swagger.response;
+
+import com.pororoz.istock.common.dto.PageResponse;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.category.dto.response.FindCategoryResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class FindCategoryResponseSwagger {
+
+  @Schema(description = "Result Code", example = ResponseStatus.OK)
+  private String status;
+
+  @Schema(description = "Message")
+  private String message;
+
+  private PageResponse<FindCategoryResponse> data;
+}

--- a/src/main/java/com/pororoz/istock/domain/user/dto/request/FindUserRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/user/dto/request/FindUserRequest.java
@@ -14,11 +14,12 @@ import lombok.Getter;
 @Builder
 public class FindUserRequest {
 
-  @Schema(description = "사용자 이름", example = "0")
+  @Schema(description = "페이지 요청", example = "0")
   @Nullable
   @PositiveOrZero(message = ExceptionMessage.INVALID_PAGE_REQUEST)
   private Integer page;
-  @Schema(description = "사용자 이름", example = "20")
+
+  @Schema(description = "사이즈 요청", example = "20")
   @Nullable
   @Positive(message = ExceptionMessage.INVALID_PAGE_REQUEST)
   private Integer size;

--- a/src/main/java/com/pororoz/istock/domain/user/entity/User.java
+++ b/src/main/java/com/pororoz/istock/domain/user/entity/User.java
@@ -2,6 +2,7 @@ package com.pororoz.istock.domain.user.entity;
 
 import com.pororoz.istock.common.entity.TimeEntity;
 import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
@@ -11,10 +12,14 @@ import jakarta.persistence.ManyToOne;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import java.io.Serializable;
+import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.convert.threeten.Jsr310JpaConverters.LocalDateTimeConverter;
 
 @Entity
 @Getter
@@ -36,6 +41,14 @@ public class User extends TimeEntity implements Serializable {
   @Size(min = 2, max = 100)
   @Column(nullable = false)
   private String password;
+
+  @CreatedDate
+  @Convert(converter = LocalDateTimeConverter.class)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Convert(converter = LocalDateTimeConverter.class)
+  private LocalDateTime updatedAt;
 
   @NotNull
   @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     open-in-view: true
     defer-datasource-initialization: true
   sql:
@@ -53,7 +53,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create
     open-in-view: true
     defer-datasource-initialization: true
   sql:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: true
     defer-datasource-initialization: true
   sql:
@@ -53,7 +53,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     open-in-view: true
     defer-datasource-initialization: true
   sql:

--- a/src/test/java/com/pororoz/istock/ResultActionsTest.java
+++ b/src/test/java/com/pororoz/istock/ResultActionsTest.java
@@ -26,10 +26,13 @@ public abstract class ResultActionsTest {
   protected ObjectMapper objectMapper;
 
 
-  protected ResultActions getResultActioForGetMethod(String url,
+  protected ResultActions getResultActionsForGetMethod(String url,
       MultiValueMap<String, String> params) throws Exception {
-    return mockMvc.perform(
-        get(url).params(params).contentType(MediaType.APPLICATION_JSON).with(csrf()));
+    return mockMvc.perform(get(url)
+        .params(params)
+        .contentType(MediaType.APPLICATION_JSON)
+        .with(csrf())
+    );
   }
 
   protected ResultActions getResultActionsWithBody(Object request, HttpMethod httpMethod,

--- a/src/test/java/com/pororoz/istock/domain/category/CategoryIntegrationTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/CategoryIntegrationTest.java
@@ -1,0 +1,269 @@
+package com.pororoz.istock.domain.category;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.pororoz.istock.common.service.DatabaseCleanup;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRequest;
+import com.pororoz.istock.domain.category.entity.Category;
+import com.pororoz.istock.domain.category.repository.CategoryRepository;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CategoryIntegrationTest {
+  @Autowired
+  MockMvc mockMvc;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  DatabaseCleanup databaseCleanup;
+
+  @AfterEach
+  public void afterEach() {
+    databaseCleanup.execute();
+  }
+
+  @Nested
+  @DisplayName("GET /v1/categories?query={}&page={}&size={} - 카테고리 리스트 조회")
+  @Transactional
+  class FindCategories {
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCase {
+
+      String url() {
+        return "/v1/categories";
+      }
+
+      String url(String name) {
+        return "/v1/categories" + "?query=" + name;
+      }
+
+      String url(int page, int size) {
+        return "/v1/categories" + "?page=" + page + "&size=" + size;
+      }
+
+      String url(String name, int page, int size) {
+        return "/v1/categories" + "?query=" + name + "&page=" + page + "&size=" + size;
+      }
+
+      @BeforeEach
+      void setup() {
+        Category category1 = Category.builder().name("item1").build();
+        Category category2 = Category.builder().name("shop1").build();
+        Category category3 = Category.builder().name("shop2").build();
+        Category category4 = Category.builder().name("item2").build();
+        Category category5 = Category.builder().name("item3").build();
+        Category category6 = Category.builder().name("button1").build();
+        Category category7 = Category.builder().name("item4").build();
+
+
+        categoryRepository.saveAll(
+            List.of(category1, category2, category3, category4, category5,category6, category7));
+      }
+
+      @Test
+      @DisplayName(
+          "카테고리 이름(=item), 페이지, 사이즈 값이 모두 들어오면 OK와 이름에 따른 검색 결과값을 전달해준다. (첫번째 페이지)")
+      void findCategoriesWithNameAndPageAndSizeForItem() throws Exception {
+        // given
+        String name = "item";
+        int itemCount = 4;
+        int page = 0;
+        int size = 2;
+        String requestUrl = url(name, page, size);
+
+        // when
+        ResultActions actions = mockMvc.perform(get(requestUrl)
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(""))
+            .andExpect(jsonPath("$.data.totalPages")
+                .value(itemCount / size))
+            .andExpect(jsonPath("$.data.totalElements").value(itemCount))
+            .andExpect(jsonPath("$.data.first").value(true))
+            .andExpect(jsonPath("$.data.last").value(false))
+            .andExpect(jsonPath("$.data.currentSize").value(2))
+            .andExpect(jsonPath("$.data.contents[0].id").value(1L))
+            .andExpect(jsonPath("$.data.contents[0].name").value("item1"))
+            .andDo(print());
+      }
+
+      @Test
+      @DisplayName(
+          "카테고리 이름(=shop), 페이지, 사이즈 값이 모두 들어오면 OK와 이름에 따른 검색 결과값을 전달해준다. "
+              + "(첫번째 페이지이자 마지막 페이지)"
+      )
+      void findCategoriesWithNameAndPageAndSizeForShop() throws Exception {
+        // given
+        String name = "shop";
+        int itemCount = 2;
+        int page = 0;
+        int size = 2;
+        String requestUrl = url(name, page, size);
+
+        // when
+        ResultActions actions = mockMvc.perform(get(requestUrl)
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(""))
+            .andExpect(jsonPath("$.data.totalPages")
+                .value(itemCount / size))
+            .andExpect(jsonPath("$.data.totalElements").value(itemCount))
+            .andExpect(jsonPath("$.data.first").value(true))
+            .andExpect(jsonPath("$.data.last").value(true))
+            .andExpect(jsonPath("$.data.currentSize").value(2))
+            .andExpect(jsonPath("$.data.contents[0].id").value(2L))
+            .andExpect(jsonPath("$.data.contents[0].name").value("shop1"))
+            .andExpect(jsonPath("$.data.contents[1].id").value(3L))
+            .andExpect(jsonPath("$.data.contents[1].name").value("shop2"))
+            .andDo(print());
+      }
+
+      @Test
+      @DisplayName("페이지, 사이즈 값이 모두 들어오면 OK와 전체에 대한 페이지 결과값을 전달해준다.(중간 페이지)")
+      void findCategoriesWithAndPageAndSize() throws Exception {
+        // given
+        int itemCount = 7;
+        int page = 1;
+        int size = 2;
+        String requestUrl = url(page, size);
+
+        // when
+        ResultActions actions = mockMvc.perform(get(requestUrl)
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(""))
+            .andExpect(jsonPath("$.data.totalPages")
+                .value((itemCount + size) / size))
+            .andExpect(jsonPath("$.data.totalElements").value(itemCount))
+            .andExpect(jsonPath("$.data.first").value(false))
+            .andExpect(jsonPath("$.data.last").value(false))
+            .andExpect(jsonPath("$.data.currentSize").value(2))
+            .andDo(print());
+      }
+
+      @Test
+      @DisplayName("페이지, 사이즈 값이 모두 들어오면 OK와 전체에 대한 페이지 결과값을 전달해준다.(마지막 페이지)")
+      void findCategoriesLastPage() throws Exception {
+        // given
+        int itemCount = 7;
+        int page = 3;
+        int size = 2;
+        String requestUrl = url(page, size);
+
+        // when
+        ResultActions actions = mockMvc.perform(get(requestUrl)
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(""))
+            .andExpect(jsonPath("$.data.totalPages")
+                .value((itemCount + size) / size))
+            .andExpect(jsonPath("$.data.totalElements").value(itemCount))
+            .andExpect(jsonPath("$.data.first").value(false))
+            .andExpect(jsonPath("$.data.last").value(true))
+            .andExpect(jsonPath("$.data.currentSize").value(1))
+            .andDo(print());
+      }
+
+      @Test
+      @DisplayName("카테고리 이름값만 받으면 default page(page=0, size=20)로 페이지네이션된 값이 반환된다.")
+      void findCategoriesWithName() throws Exception {
+        // given
+        int itemCount = 4;
+        String name = "item";
+        String requestUrl = url(name);
+        int defaultSize = FindCategoryServiceRequest.DEFAULT_SIZE;
+
+        // when
+        ResultActions actions = mockMvc.perform(get(requestUrl)
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(""))
+            .andExpect(jsonPath("$.data.totalPages")
+                .value((itemCount+defaultSize) / defaultSize))
+            .andExpect(jsonPath("$.data.totalElements").value(itemCount))
+            .andExpect(jsonPath("$.data.first").value(true))
+            .andExpect(jsonPath("$.data.last").value(true))
+            .andExpect(jsonPath("$.data.currentSize").value(itemCount))
+            .andDo(print());
+      }
+
+      @Test
+      @DisplayName(
+          "아무값도 쿼리로 넘겨주지 않으면 전체를 대상으로 default page(page=0, size=20)로 페이지네이션된 값이 반환된다.")
+      void findCategoriesWithNull() throws Exception {
+        // given
+        int itemCount = 7;
+        String requestUrl = url();
+        int defaultSize = FindCategoryServiceRequest.DEFAULT_SIZE;
+
+        // when
+        ResultActions actions = mockMvc.perform(get(requestUrl)
+            .contentType(MediaType.APPLICATION_JSON));
+
+        // then
+        actions.andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(""))
+            .andExpect(jsonPath("$.data.totalPages")
+                .value((itemCount+defaultSize) / defaultSize))
+            .andExpect(jsonPath("$.data.totalElements").value(itemCount))
+            .andExpect(jsonPath("$.data.first").value(true))
+            .andExpect(jsonPath("$.data.last").value(true))
+            .andExpect(jsonPath("$.data.currentSize").value(itemCount))
+            .andDo(print());
+      }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailCase {
+
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
@@ -90,7 +90,7 @@ class CategoryControllerTest extends ControllerTest {
         //when
         when(categoryService.findCategories(any(FindCategoryServiceRequest.class))).thenReturn(
             responsePage);
-        ResultActions actions = getResultActioForGetMethod(url, params);
+        ResultActions actions = getResultActionsForGetMethod(url, params);
 
         //then
         actions.andExpect(status().isOk())

--- a/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
@@ -66,7 +66,7 @@ class CategoryControllerTest {
         int pages = 2;
         int countPerPages = 2;
         LocalDateTime today = LocalDateTime.now();
-        FindCategoryRequest request = FindCategoryRequest.builder().name(name)
+        FindCategoryRequest request = FindCategoryRequest.builder().query(name)
             .page(pages).size(countPerPages).build();
 
         Page<FindCategoryServiceResponse> responsePage = new PageImpl<>(findCategoryServiceResponses,

--- a/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
@@ -9,10 +9,11 @@ import static org.mockito.Mockito.when;
 import com.pororoz.istock.common.dto.PageResponse;
 import com.pororoz.istock.common.dto.ResultDTO;
 import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.category.dto.request.FindCategoryRequest;
+import com.pororoz.istock.domain.category.dto.response.FindCategoryResponse;
 import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRequest;
 import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceResponse;
 import com.pororoz.istock.domain.category.service.CategoryService;
-import com.pororoz.istock.domain.user.dto.response.FindUserResponse;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.List;
@@ -31,7 +32,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 @ExtendWith(MockitoExtension.class)
-class UserControllerTest {
+class CategoryControllerTest {
 
   @InjectMocks
   CategoryController categoryController;
@@ -70,27 +71,27 @@ class UserControllerTest {
 
         Page<FindCategoryServiceResponse> responsePage = new PageImpl<>(findCategoryServiceResponses,
             PageRequest.of(3, countPerPages), totalCategories);
-        List<FindUserResponse> findUserResponse = List.of(
+        List<FindCategoryResponse> findCategoryResponses = List.of(
             response1.toResponse(), response2.toResponse());
 
         //when
         when(categoryService.findCategories(any(FindCategoryServiceRequest.class))).thenReturn(responsePage);
-        ResponseEntity<ResultDTO<PageResponse<FindUserResponse>>> response
+        ResponseEntity<ResultDTO<PageResponse<FindCategoryResponse>>> response
             = categoryController.findCategories(request);
 
         //then
         assertEquals(response.getStatusCode(), HttpStatus.OK);
         assertEquals(Objects.requireNonNull(response.getBody()).getStatus(), ResponseStatus.OK);
 
-        PageResponse<FindUserResponse> data = Objects.requireNonNull(response.getBody()).getData();
+        PageResponse<FindCategoryResponse> data = Objects.requireNonNull(response.getBody()).getData();
         assertEquals(data.getTotalPages(), (int) (totalCategories + countPerPages) / countPerPages);
         assertEquals(data.getTotalElements(), totalCategories);
         assertEquals(data.getCurrentSize(), countPerPages);
         assertFalse(data.isFirst());
         assertFalse(data.isLast());
-        assertIterableEquals(data.getContents(), findUserResponse);
+        assertIterableEquals(data.getContents(), findCategoryResponses);
 
-        FindUserResponse first = data.getContents().get(0);
+        FindCategoryResponse first = data.getContents().get(0);
         String format = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
         assertEquals(first.getCreatedAt(), format);
         assertEquals(first.getUpdatedAt(), format);

--- a/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/controller/CategoryControllerTest.java
@@ -1,0 +1,106 @@
+package com.pororoz.istock.domain.category.controller;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertIterableEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.pororoz.istock.common.dto.PageResponse;
+import com.pororoz.istock.common.dto.ResultDTO;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRequest;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceResponse;
+import com.pororoz.istock.domain.category.service.CategoryService;
+import com.pororoz.istock.domain.user.dto.response.FindUserResponse;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+@ExtendWith(MockitoExtension.class)
+class UserControllerTest {
+
+  @InjectMocks
+  CategoryController categoryController;
+
+  @Mock
+  CategoryService categoryService;
+
+  @Nested
+  @DisplayName("계정 조회")
+  class FindUser {
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCase {
+
+      @Test
+      @DisplayName("2번 페이지를 조회한다.")
+      void findCategories() {
+        //given
+        LocalDateTime create = LocalDateTime.now();
+        LocalDateTime update = LocalDateTime.now();
+        FindCategoryServiceResponse response1 = FindCategoryServiceResponse.builder().id(1L)
+            .name("item1").createdAt(create).updatedAt(update).build();
+        FindCategoryServiceResponse response2 = FindCategoryServiceResponse.builder().id(1L)
+            .name("item2").createdAt(create).updatedAt(update).build();
+        List<FindCategoryServiceResponse> findCategoryServiceResponses = List.of(response1, response2);
+
+
+        long totalCategories = 11L;
+        String name = "item";
+        int pages = 2;
+        int countPerPages = 2;
+        LocalDateTime today = LocalDateTime.now();
+        FindCategoryRequest request = FindCategoryRequest.builder().name(name)
+            .page(pages).size(countPerPages).build();
+
+        Page<FindCategoryServiceResponse> responsePage = new PageImpl<>(findCategoryServiceResponses,
+            PageRequest.of(3, countPerPages), totalCategories);
+        List<FindUserResponse> findUserResponse = List.of(
+            response1.toResponse(), response2.toResponse());
+
+        //when
+        when(categoryService.findCategories(any(FindCategoryServiceRequest.class))).thenReturn(responsePage);
+        ResponseEntity<ResultDTO<PageResponse<FindUserResponse>>> response
+            = categoryController.findCategories(request);
+
+        //then
+        assertEquals(response.getStatusCode(), HttpStatus.OK);
+        assertEquals(Objects.requireNonNull(response.getBody()).getStatus(), ResponseStatus.OK);
+
+        PageResponse<FindUserResponse> data = Objects.requireNonNull(response.getBody()).getData();
+        assertEquals(data.getTotalPages(), (int) (totalCategories + countPerPages) / countPerPages);
+        assertEquals(data.getTotalElements(), totalCategories);
+        assertEquals(data.getCurrentSize(), countPerPages);
+        assertFalse(data.isFirst());
+        assertFalse(data.isLast());
+        assertIterableEquals(data.getContents(), findUserResponse);
+
+        FindUserResponse first = data.getContents().get(0);
+        String format = today.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));
+        assertEquals(first.getCreatedAt(), format);
+        assertEquals(first.getUpdatedAt(), format);
+      }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailCase {
+
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponseTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/dto/response/FindCategoryResponseTest.java
@@ -1,0 +1,101 @@
+package com.pororoz.istock.domain.category.dto.response;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pororoz.istock.common.entity.TimeEntity;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceResponse;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FindCategoryResponseTest {
+
+  @Nested
+  @DisplayName("FindCategoryResponse - equals()")
+  class EqualsTest {
+
+    @Test
+    @DisplayName("서로 다른 인스턴스지만 인스턴스화한 클래스와 그 내용이 같다면 true를 반환한다.")
+    void similarObj() {
+      // given
+      String now = TimeEntity.formatTime(LocalDateTime.now());
+      FindCategoryResponse findCategoryResponse1 = FindCategoryResponse.builder().id(1L)
+          .name("item").createdAt(now).updatedAt(now).build();
+      FindCategoryResponse findCategoryResponse2 = FindCategoryResponse.builder().id(1L)
+          .name("item").createdAt(now).updatedAt(now).build();
+
+      // when
+      // then
+      assertTrue(findCategoryResponse1.equals(findCategoryResponse2));
+    }
+
+    @Test
+    @DisplayName("아예 같은 Object라면 true를 반환한다.")
+    void sameObj() {
+      // given
+      FindCategoryResponse findCategoryResponse = FindCategoryResponse.builder().id(1L).name("item")
+          .createdAt(TimeEntity.formatTime(LocalDateTime.now()))
+          .updatedAt(TimeEntity.formatTime(LocalDateTime.now())).build();
+      Object obj = findCategoryResponse;
+
+      // when
+      // then
+      assertTrue(findCategoryResponse.equals(obj));
+    }
+
+    @Test
+    @DisplayName("Object가 null이면 false를 반환한다.")
+    void nullObj() {
+      // given
+      FindCategoryResponse findCategoryResponse = FindCategoryResponse.builder().id(1L).name("item")
+          .createdAt(TimeEntity.formatTime(LocalDateTime.now()))
+          .updatedAt(TimeEntity.formatTime(LocalDateTime.now())).build();
+      Object obj = null;
+
+      // when
+      // then
+      assertFalse(findCategoryResponse.equals(obj));
+    }
+
+    @Test
+    @DisplayName("Object가 내용물이 같아도 클래스가 다르면 false를 반환한다.")
+    void notSameClass() {
+      // given
+      FindCategoryResponse findCategoryResponse = FindCategoryResponse.builder().id(1L).name("item")
+          .createdAt(null).updatedAt(null).build();
+      FindCategoryServiceResponse findCategoryServiceResponse = FindCategoryServiceResponse.builder()
+          .id(1L).name("item").createdAt(null).updatedAt(null).build();
+
+      // when
+      // then
+      assertFalse(findCategoryResponse.equals(findCategoryServiceResponse));
+    }
+  }
+
+  @Nested
+  @DisplayName("FindCategoryResponse - hashCode()")
+  class HashCode {
+
+    @Test
+    @DisplayName("다른 인스턴스여도 내용이 같다면 같은 해시코드를 반환한다.")
+    void similarObj() {
+      // given
+      String now = TimeEntity.formatTime(LocalDateTime.now());
+      FindCategoryResponse findCategoryResponse1 = FindCategoryResponse.builder().id(1L)
+          .name("item").createdAt(now).updatedAt(now).build();
+      FindCategoryResponse findCategoryResponse2 = FindCategoryResponse.builder().id(1L)
+          .name("item").createdAt(now).updatedAt(now).build();
+
+      // when
+      // then
+      assertThat(findCategoryResponse1.hashCode(), equalTo(findCategoryResponse2.hashCode()));
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceResponseTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/dto/service/FindCategoryServiceResponseTest.java
@@ -1,0 +1,130 @@
+package com.pororoz.istock.domain.category.dto.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pororoz.istock.domain.category.dto.response.FindCategoryResponse;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class FindCategoryServiceResponseTest {
+
+  @Nested
+  @DisplayName("FindCategoryServiceResponse - equals()")
+  class EqualsTest {
+
+    @Test
+    @DisplayName("서로 다른 인스턴스지만 인스턴스화한 클래스와 그 내용이 같다면 true를 반환한다.")
+    void similarObj() {
+      // given
+      LocalDateTime now = LocalDateTime.now();
+      FindCategoryServiceResponse findCategoryServiceResponse1 = FindCategoryServiceResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
+      FindCategoryServiceResponse findCategoryServiceResponse2 = FindCategoryServiceResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
+
+      // when
+      // then
+      assertTrue(findCategoryServiceResponse1.equals(findCategoryServiceResponse2));
+    }
+
+    @Test
+    @DisplayName("아예 같은 Object라면 true를 반환한다.")
+    void sameObj() {
+      // given
+      LocalDateTime now = LocalDateTime.now();
+      FindCategoryServiceResponse findCategoryServiceResponse = FindCategoryServiceResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
+      Object obj = findCategoryServiceResponse;
+
+      // when
+      // then
+      assertTrue(findCategoryServiceResponse.equals(obj));
+    }
+
+    @Test
+    @DisplayName("Object가 null이면 false를 반환한다.")
+    void nullObj() {
+      // given
+      LocalDateTime now = LocalDateTime.now();
+      FindCategoryServiceResponse findCategoryServiceResponse = FindCategoryServiceResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
+      Object obj = null;
+
+      // when
+      // then
+      assertFalse(findCategoryServiceResponse.equals(obj));
+    }
+
+    @Test
+    @DisplayName("Object가 내용물이 같아도 클래스가 다르면 false를 반환한다.")
+    void notSameClass() {
+      // given
+      FindCategoryResponse findCategoryResponse = FindCategoryResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(null)
+          .updatedAt(null)
+          .build();
+      FindCategoryServiceResponse findCategoryServiceResponse = FindCategoryServiceResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(null)
+          .updatedAt(null)
+          .build();
+
+      // when
+      // then
+      assertFalse(findCategoryServiceResponse.equals(findCategoryResponse));
+    }
+  }
+
+  @Nested
+  @DisplayName("FindCategoryResponse - hashCode()")
+  class HashCode {
+
+    @Test
+    @DisplayName("다른 인스턴스여도 내용이 같다면 같은 해시코드를 반환한다.")
+    void similarObj() {
+      // given
+      LocalDateTime now = LocalDateTime.now();
+      FindCategoryServiceResponse findCategoryServiceResponse1 = FindCategoryServiceResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
+      FindCategoryServiceResponse findCategoryServiceResponse2 = FindCategoryServiceResponse.builder()
+          .id(1L)
+          .name("item")
+          .createdAt(now)
+          .updatedAt(now)
+          .build();
+
+      // when
+      // then
+      assertThat(findCategoryServiceResponse1.hashCode(),
+          equalTo(findCategoryServiceResponse2.hashCode()));
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
@@ -3,7 +3,10 @@ package com.pororoz.istock.domain.category.service;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
+import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceRequest;
+import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceResponse;
 import com.pororoz.istock.domain.category.entity.Category;
 import com.pororoz.istock.domain.category.repository.CategoryRepository;
 import java.time.LocalDateTime;
@@ -11,12 +14,15 @@ import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 
+@ExtendWith(MockitoExtension.class)
 class CategoryServiceTest {
   @InjectMocks
   CategoryService categoryService;
@@ -32,14 +38,15 @@ class CategoryServiceTest {
     class SuccessCase {
 
       @Test
-      @DisplayName("검색을 하지 않았을 때 페이지네이션을 한 ")
+      @DisplayName("카테고리 이름을 검색해 조회하면 페이지네이션을 한다.")
       void getCategory() {
         // given
         LocalDateTime create = LocalDateTime.now();
         LocalDateTime update = LocalDateTime.now();
-        long totalCategories = 10L;
+        long totalCategories = 11L;
         int size = 2;
         int page = 3;
+        String name = "item";
         Category category1 = Category.builder()
             .id(1L)
             .name("item1")
@@ -55,15 +62,15 @@ class CategoryServiceTest {
         List<Category> categories = List.of(category1, category2);
 
         GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
-            .name()
-            .page()
-            .size()
+            .name(name)
+            .page(page)
+            .size(size)
             .build();
         PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size), totalCategories);
         List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(categories);
 
         // when
-        when(categoryRepository.findByName(any())).thenReturn(pages);
+        when(categoryRepository.findAllByNameContaining(any(), any())).thenReturn(pages);
         Page<GetCategoryServiceResponse> result = categoryService.findCategories(getCategoryServiceRequest);
 
         // then
@@ -82,10 +89,10 @@ class CategoryServiceTest {
 
     }
 
-    private List<GetCategoryServiceRequest> makeCategoryServiceResponses(List<Category> categories) {
+    private List<GetCategoryServiceResponse> makeCategoryServiceResponses(List<Category> categories) {
       return categories.stream().map(
-          category -> GetCategoryServiceRequest.builder().id(category.getId()).name(category.getName())
-              .createAt(category.getCreatedAt()).updateAt(category.getUpdatedAt()).build()).toList();
+          category -> GetCategoryServiceResponse.builder().id(category.getId()).name(category.getName())
+              .createdAt(category.getCreatedAt()).updatedAt(category.getUpdatedAt()).build()).toList();
     }
   }
 }

--- a/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
@@ -1,0 +1,91 @@
+package com.pororoz.istock.domain.category.service;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+
+import com.pororoz.istock.domain.category.entity.Category;
+import com.pororoz.istock.domain.category.repository.CategoryRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+
+class CategoryServiceTest {
+  @InjectMocks
+  CategoryService categoryService;
+
+  @Mock
+  CategoryRepository categoryRepository;
+
+  @Nested
+  @DisplayName("카테고리 조회 API")
+  class GetCategory {
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCase {
+
+      @Test
+      @DisplayName("검색을 하지 않았을 때 페이지네이션을 한 ")
+      void getCategory() {
+        // given
+        LocalDateTime create = LocalDateTime.now();
+        LocalDateTime update = LocalDateTime.now();
+        long totalCategories = 10L;
+        int size = 2;
+        int page = 3;
+        Category category1 = Category.builder()
+            .id(1L)
+            .name("item1")
+            .createdAt(create)
+            .updatedAt(update)
+            .build();
+        Category category2 = Category.builder()
+            .id(2L)
+            .name("item2")
+            .createdAt(create)
+            .updatedAt(update)
+            .build();
+        List<Category> categories = List.of(category1, category2);
+
+        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+            .name()
+            .page()
+            .size()
+            .build();
+        PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size), totalCategories);
+        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(categories);
+
+        // when
+        when(categoryRepository.findByName(any())).thenReturn(pages);
+        Page<GetCategoryServiceResponse> result = categoryService.findCategories(getCategoryServiceRequest);
+
+        // then
+        assertThat(result.getTotalElements(), equalTo(totalCategories));
+        assertThat(result.getTotalPages(),
+            equalTo((int) (totalCategories + size) / size));
+        assertThat(result.getContent().size(), equalTo(size));
+        assertThat(result.getContent().get(0), equalTo(getCategoryServiceResponses.get(0)));
+        assertThat(result.getContent().get(1), equalTo(getCategoryServiceResponses.get(1)));
+      }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailCase {
+
+    }
+
+    private List<GetCategoryServiceRequest> makeCategoryServiceResponses(List<Category> categories) {
+      return categories.stream().map(
+          category -> GetCategoryServiceRequest.builder().id(category.getId()).name(category.getName())
+              .createAt(category.getCreatedAt()).updateAt(category.getUpdatedAt()).build()).toList();
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
@@ -7,8 +7,8 @@ import static org.junit.jupiter.api.Assertions.assertIterableEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
-import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceRequest;
-import com.pororoz.istock.domain.category.dto.service.GetCategoryServiceResponse;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceRequest;
+import com.pororoz.istock.domain.category.dto.service.FindCategoryServiceResponse;
 import com.pororoz.istock.domain.category.entity.Category;
 import com.pororoz.istock.domain.category.repository.CategoryRepository;
 import java.time.LocalDateTime;
@@ -77,19 +77,19 @@ class CategoryServiceTest {
         int page = 3;
         String name = "item";
 
-        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+        FindCategoryServiceRequest getCategoryServiceRequest = FindCategoryServiceRequest.builder()
             .name(name)
             .page(page)
             .size(size)
             .build();
         PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size),
             totalCategories);
-        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+        List<FindCategoryServiceResponse> findCategoryServiceRespons = makeCategoryServiceResponses(
             categories);
 
         // when
         when(categoryRepository.findAllByNameContaining(any(), any())).thenReturn(pages);
-        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+        Page<FindCategoryServiceResponse> result = categoryService.findCategories(
             getCategoryServiceRequest);
 
         // then
@@ -97,8 +97,8 @@ class CategoryServiceTest {
         assertThat(result.getTotalPages(),
             equalTo((int) (totalCategories + size) / size));
         assertThat(result.getContent().size(), equalTo(size));
-        assertThat(result.getContent().get(0), equalTo(getCategoryServiceResponses.get(0)));
-        assertThat(result.getContent().get(1), equalTo(getCategoryServiceResponses.get(1)));
+        assertThat(result.getContent().get(0), equalTo(findCategoryServiceRespons.get(0)));
+        assertThat(result.getContent().get(1), equalTo(findCategoryServiceRespons.get(1)));
       }
 
       @Test
@@ -109,19 +109,19 @@ class CategoryServiceTest {
         int size = 2;
         int page = 3;
 
-        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+        FindCategoryServiceRequest getCategoryServiceRequest = FindCategoryServiceRequest.builder()
             .name(null)
             .page(page)
             .size(size)
             .build();
         PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size),
             totalCategories);
-        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+        List<FindCategoryServiceResponse> findCategoryServiceRespons = makeCategoryServiceResponses(
             categories);
 
         // when
         when(categoryRepository.findAllByNameContaining(any(Pageable.class))).thenReturn(pages);
-        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+        Page<FindCategoryServiceResponse> result = categoryService.findCategories(
             getCategoryServiceRequest);
 
         // then
@@ -129,8 +129,8 @@ class CategoryServiceTest {
         assertThat(result.getTotalPages(),
             equalTo((int) (totalCategories + size) / size));
         assertThat(result.getContent().size(), equalTo(size));
-        assertThat(result.getContent().get(0), equalTo(getCategoryServiceResponses.get(0)));
-        assertThat(result.getContent().get(1), equalTo(getCategoryServiceResponses.get(1)));
+        assertThat(result.getContent().get(0), equalTo(findCategoryServiceRespons.get(0)));
+        assertThat(result.getContent().get(1), equalTo(findCategoryServiceRespons.get(1)));
       }
 
       @Test
@@ -139,21 +139,21 @@ class CategoryServiceTest {
         // given
         String name = "item";
 
-        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+        FindCategoryServiceRequest getCategoryServiceRequest = FindCategoryServiceRequest.builder()
             .name(name)
             .page(null)
             .size(null)
             .build();
-        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+        List<FindCategoryServiceResponse> findCategoryServiceRespons = makeCategoryServiceResponses(
             categories);
 
         // when
         when(categoryRepository.findAllByNameContaining(any(String.class))).thenReturn(categories);
-        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+        Page<FindCategoryServiceResponse> result = categoryService.findCategories(
             getCategoryServiceRequest);
 
         // then
-        assertIterableEquals(result.getContent(), getCategoryServiceResponses);
+        assertIterableEquals(result.getContent(), findCategoryServiceRespons);
         assertEquals(result.getTotalElements(), result.getNumberOfElements());
         assertEquals(result.getTotalPages(), 1);
       }
@@ -162,21 +162,21 @@ class CategoryServiceTest {
       @DisplayName("page와 size가 null이면 전체를 조회한다.")
       void getCategoryWithNull() {
         // given
-        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+        FindCategoryServiceRequest getCategoryServiceRequest = FindCategoryServiceRequest.builder()
             .name(null)
             .page(null)
             .size(null)
             .build();
-        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+        List<FindCategoryServiceResponse> findCategoryServiceRespons = makeCategoryServiceResponses(
             categories);
 
         // when
         when(categoryRepository.findAll()).thenReturn(categories);
-        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+        Page<FindCategoryServiceResponse> result = categoryService.findCategories(
             getCategoryServiceRequest);
 
         // then
-        assertIterableEquals(result.getContent(), getCategoryServiceResponses);
+        assertIterableEquals(result.getContent(), findCategoryServiceRespons);
         assertEquals(result.getTotalElements(), result.getNumberOfElements());
         assertEquals(result.getTotalPages(), 1);
       }
@@ -188,10 +188,10 @@ class CategoryServiceTest {
 
     }
 
-    private List<GetCategoryServiceResponse> makeCategoryServiceResponses(
+    private List<FindCategoryServiceResponse> makeCategoryServiceResponses(
         List<Category> categories) {
       return categories.stream().map(
-              category -> GetCategoryServiceResponse.builder().id(category.getId())
+              category -> FindCategoryServiceResponse.builder().id(category.getId())
                   .name(category.getName())
                   .createdAt(category.getCreatedAt()).updatedAt(category.getUpdatedAt()).build())
           .toList();

--- a/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/category/service/CategoryServiceTest.java
@@ -13,6 +13,7 @@ import com.pororoz.istock.domain.category.entity.Category;
 import com.pororoz.istock.domain.category.repository.CategoryRepository;
 import java.time.LocalDateTime;
 import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,6 +28,7 @@ import org.springframework.data.domain.Pageable;
 
 @ExtendWith(MockitoExtension.class)
 class CategoryServiceTest {
+
   @InjectMocks
   CategoryService categoryService;
 
@@ -36,46 +38,59 @@ class CategoryServiceTest {
   @Nested
   @DisplayName("카테고리 조회 API")
   class GetCategory {
+
     @Nested
     @DisplayName("성공 케이스")
     class SuccessCase {
 
+      LocalDateTime create;
+      LocalDateTime update;
+      Category category1;
+      Category category2;
+      List<Category> categories;
 
-      @Test
-      @DisplayName("카테고리 이름을 검색해 조회하면 페이지네이션을 한다.")
-      void getCategoryWithNameAndPageAndSize() {
-        // given
-        LocalDateTime create = LocalDateTime.now();
-        LocalDateTime update = LocalDateTime.now();
-        long totalCategories = 11L;
-        int size = 2;
-        int page = 3;
-        String name = "item";
-        Category category1 = Category.builder()
+      @BeforeEach
+      void setup() {
+        create = LocalDateTime.now();
+        update = LocalDateTime.now();
+        category1 = Category.builder()
             .id(1L)
             .name("item1")
             .createdAt(create)
             .updatedAt(update)
             .build();
-        Category category2 = Category.builder()
+        category2 = Category.builder()
             .id(2L)
             .name("item2")
             .createdAt(create)
             .updatedAt(update)
             .build();
-        List<Category> categories = List.of(category1, category2);
+        categories = List.of(category1, category2);
+      }
+
+      @Test
+      @DisplayName("카테고리 이름을 검색해 조회하면 페이지네이션을 한다.")
+      void getCategoryWithNameAndPageAndSize() {
+        // given
+        long totalCategories = 11L;
+        int size = 2;
+        int page = 3;
+        String name = "item";
 
         GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
             .name(name)
             .page(page)
             .size(size)
             .build();
-        PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size), totalCategories);
-        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(categories);
+        PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size),
+            totalCategories);
+        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+            categories);
 
         // when
         when(categoryRepository.findAllByNameContaining(any(), any())).thenReturn(pages);
-        Page<GetCategoryServiceResponse> result = categoryService.findCategories(getCategoryServiceRequest);
+        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+            getCategoryServiceRequest);
 
         // then
         assertThat(result.getTotalElements(), equalTo(totalCategories));
@@ -85,137 +100,101 @@ class CategoryServiceTest {
         assertThat(result.getContent().get(0), equalTo(getCategoryServiceResponses.get(0)));
         assertThat(result.getContent().get(1), equalTo(getCategoryServiceResponses.get(1)));
       }
+
+      @Test
+      @DisplayName("검색 없이 조회하면 전체를 대상으로 페이지네이션을 한다.")
+      void getCategoryWithOnlyPage() {
+        // given
+        long totalCategories = 11L;
+        int size = 2;
+        int page = 3;
+
+        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+            .name(null)
+            .page(page)
+            .size(size)
+            .build();
+        PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size),
+            totalCategories);
+        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+            categories);
+
+        // when
+        when(categoryRepository.findAllByNameContaining(any(Pageable.class))).thenReturn(pages);
+        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+            getCategoryServiceRequest);
+
+        // then
+        assertThat(result.getTotalElements(), equalTo(totalCategories));
+        assertThat(result.getTotalPages(),
+            equalTo((int) (totalCategories + size) / size));
+        assertThat(result.getContent().size(), equalTo(size));
+        assertThat(result.getContent().get(0), equalTo(getCategoryServiceResponses.get(0)));
+        assertThat(result.getContent().get(1), equalTo(getCategoryServiceResponses.get(1)));
+      }
+
+      @Test
+      @DisplayName("page와 size가 null이고 이름만 검색할 경우 이름값에 해당하는 전체 값을 준다.")
+      void getCategoryWithOnlyName() {
+        // given
+        String name = "item";
+
+        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+            .name(name)
+            .page(null)
+            .size(null)
+            .build();
+        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+            categories);
+
+        // when
+        when(categoryRepository.findAllByNameContaining(any(String.class))).thenReturn(categories);
+        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+            getCategoryServiceRequest);
+
+        // then
+        assertIterableEquals(result.getContent(), getCategoryServiceResponses);
+        assertEquals(result.getTotalElements(), result.getNumberOfElements());
+        assertEquals(result.getTotalPages(), 1);
+      }
+
+      @Test
+      @DisplayName("page와 size가 null이면 전체를 조회한다.")
+      void getCategoryWithNull() {
+        // given
+        GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
+            .name(null)
+            .page(null)
+            .size(null)
+            .build();
+        List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(
+            categories);
+
+        // when
+        when(categoryRepository.findAll()).thenReturn(categories);
+        Page<GetCategoryServiceResponse> result = categoryService.findCategories(
+            getCategoryServiceRequest);
+
+        // then
+        assertIterableEquals(result.getContent(), getCategoryServiceResponses);
+        assertEquals(result.getTotalElements(), result.getNumberOfElements());
+        assertEquals(result.getTotalPages(), 1);
+      }
     }
 
-    @Test
-    @DisplayName("검색 없이 조회하면 전체를 대상으로 페이지네이션을 한다.")
-    void getCategoryWithOnlyPage() {
-      // given
-      LocalDateTime create = LocalDateTime.now();
-      LocalDateTime update = LocalDateTime.now();
-      long totalCategories = 11L;
-      int size = 2;
-      int page = 3;
-      Category category1 = Category.builder()
-          .id(1L)
-          .name("item1")
-          .createdAt(create)
-          .updatedAt(update)
-          .build();
-      Category category2 = Category.builder()
-          .id(2L)
-          .name("item2")
-          .createdAt(create)
-          .updatedAt(update)
-          .build();
-      List<Category> categories = List.of(category1, category2);
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailCase {
 
-      GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
-          .name(null)
-          .page(page)
-          .size(size)
-          .build();
-      PageImpl<Category> pages = new PageImpl<>(categories, PageRequest.of(page, size), totalCategories);
-      List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(categories);
-
-      // when
-      when(categoryRepository.findAllByNameContaining(any(Pageable.class))).thenReturn(pages);
-      Page<GetCategoryServiceResponse> result = categoryService.findCategories(getCategoryServiceRequest);
-
-      // then
-      assertThat(result.getTotalElements(), equalTo(totalCategories));
-      assertThat(result.getTotalPages(),
-          equalTo((int) (totalCategories + size) / size));
-      assertThat(result.getContent().size(), equalTo(size));
-      assertThat(result.getContent().get(0), equalTo(getCategoryServiceResponses.get(0)));
-      assertThat(result.getContent().get(1), equalTo(getCategoryServiceResponses.get(1)));
     }
 
-    @Test
-    @DisplayName("page와 size가 null이고 이름만 검색할 경우 이름값에 해당하는 전체 값을 준다.")
-    void getCategoryWithOnlyName() {
-      // given
-      LocalDateTime create = LocalDateTime.now();
-      LocalDateTime update = LocalDateTime.now();
-      String name = "";
-      Category category1 = Category.builder()
-          .id(1L)
-          .name("item1")
-          .createdAt(create)
-          .updatedAt(update)
-          .build();
-      Category category2 = Category.builder()
-          .id(2L)
-          .name("item2")
-          .createdAt(create)
-          .updatedAt(update)
-          .build();
-      List<Category> categories = List.of(category1, category2);
-
-      GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
-          .name(name)
-          .page(null)
-          .size(null)
-          .build();
-      List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(categories);
-
-      // when
-      when(categoryRepository.findAllByNameContaining(any(String.class))).thenReturn(categories);
-      Page<GetCategoryServiceResponse> result = categoryService.findCategories(getCategoryServiceRequest);
-
-      // then
-      assertIterableEquals(result.getContent(), getCategoryServiceResponses);
-      assertEquals(result.getTotalElements(), result.getNumberOfElements());
-      assertEquals(result.getTotalPages(), 1);
+    private List<GetCategoryServiceResponse> makeCategoryServiceResponses(
+        List<Category> categories) {
+      return categories.stream().map(
+              category -> GetCategoryServiceResponse.builder().id(category.getId())
+                  .name(category.getName())
+                  .createdAt(category.getCreatedAt()).updatedAt(category.getUpdatedAt()).build())
+          .toList();
     }
-
-    @Test
-    @DisplayName("page와 size가 null이면 전체를 조회한다.")
-    void getCategoryWithNull() {
-      // given
-      LocalDateTime create = LocalDateTime.now();
-      LocalDateTime update = LocalDateTime.now();
-      Category category1 = Category.builder()
-          .id(1L)
-          .name("item1")
-          .createdAt(create)
-          .updatedAt(update)
-          .build();
-      Category category2 = Category.builder()
-          .id(2L)
-          .name("item2")
-          .createdAt(create)
-          .updatedAt(update)
-          .build();
-      List<Category> categories = List.of(category1, category2);
-
-      GetCategoryServiceRequest getCategoryServiceRequest = GetCategoryServiceRequest.builder()
-          .name(null)
-          .page(null)
-          .size(null)
-          .build();
-      List<GetCategoryServiceResponse> getCategoryServiceResponses = makeCategoryServiceResponses(categories);
-
-      // when
-      when(categoryRepository.findAll()).thenReturn(categories);
-      Page<GetCategoryServiceResponse> result = categoryService.findCategories(getCategoryServiceRequest);
-
-      // then
-      assertIterableEquals(result.getContent(), getCategoryServiceResponses);
-      assertEquals(result.getTotalElements(), result.getNumberOfElements());
-      assertEquals(result.getTotalPages(), 1);
-    }
-  }
-
-  @Nested
-  @DisplayName("실패 케이스")
-  class FailCase {
-
-  }
-
-  private List<GetCategoryServiceResponse> makeCategoryServiceResponses(List<Category> categories) {
-    return categories.stream().map(
-        category -> GetCategoryServiceResponse.builder().id(category.getId()).name(category.getName())
-            .createdAt(category.getCreatedAt()).updatedAt(category.getUpdatedAt()).build()).toList();
   }
 }


### PR DESCRIPTION
## 개요

- 카테고리 리스트를 조회하는 API
- 페이지네이션 적용
- 카테고리 이름 검색 적용

## 세부 내용

<h2>카테고리 리스트 조회</h2>
<ul>
<li>
<p>시스템에 등록된 Product(제품) 카테고리를 조회하는 기능</p>
</li>
<li>
<p>카테고리 이름 검색 기능</p>
</li>
<li>
<p>query에 넘긴 파라미터로 category name을 조회할 수 있다.</p>
</li>
<li>
<p><strong>query</strong></p>


GET | /api/v1/categories?query={}&page={}&size={}
-- | --



</li>
<li>
<p><strong>response</strong></p>
</li>
</ul>
<pre><code class="language-json">{
	status: &quot;OK&quot;,
	message: &quot;&quot;,
	data:{
		totalPages: 20,
		totalElements: 100,
		currentSize: 5,
		first: true,
		last: false,
		contents: {
			[
				{
					id:1
					categoryName:&quot;CONTROLLER&quot;,
					createdAt:&quot;2023-01-16 13:01:23&quot;
					updatedAt:&quot;2023-01-16 13:01:23&quot;
				},
				...
			],
		}
	}
}
</code></pre>


## 공유 (중요!!!)

- User 조회에서 페이지네이션을 적용한 것이 있고 안 한 것이 있는데 그냥 페이지네이션을 전부 적용하는 것이 좋지 않을까하는 고민이 듭니다.
- 만약 카테고리가 너무 많거나, 유저가 너무 많을 때 전체 값을 대상으로 GET 요청을 보내면 서버 자원에 낭비가 발생할 수 있기 때문에 모든 경우에 페이지네이션을 적용하는 것이 좋을 것 같다고 생각해 저는 카테고리에 한해 페이지네이션을 적용해놓은 상태입니다.
- @Darkeroe @dohyeon-han 어떻게 생각하시나요

<br/>
