### PR TITLE
[Feature] 권한 강등 예외 처리

### DIFF
--- a/src/main/java/com/pororoz/istock/common/exception/ErrorCode.java
+++ b/src/main/java/com/pororoz/istock/common/exception/ErrorCode.java
@@ -30,6 +30,8 @@ public enum ErrorCode {
       ExceptionMessage.DUPLICATE_BOM),
   BOM_NOT_FOUND(HttpStatus.NOT_FOUND, ExceptionStatus.BOM_NOT_FOUND,
       ExceptionMessage.BOM_NOT_FOUND),
+  SELF_DEMOTE_ROLE(HttpStatus.BAD_REQUEST, ExceptionStatus.SELF_DEMOTE_ROLE,
+      ExceptionMessage.SELF_DEMOTE_ROLE)
   ;
 
   private final HttpStatus statusCode;

--- a/src/main/java/com/pororoz/istock/common/utils/message/ExceptionMessage.java
+++ b/src/main/java/com/pororoz/istock/common/utils/message/ExceptionMessage.java
@@ -24,6 +24,7 @@ public class ExceptionMessage {
   public static final String PRODUCT_NOT_FOUND = "해당 제품을 찾을 수 없습니다.";
   public static final String DUPLICATE_BOM = "location_number, product_id, part_id의 조합이 중복됩니다.";
   public static final String BOM_NOT_FOUND = "존재하지 않는 BOM입니다.";
+  public static final String SELF_DEMOTE_ROLE = "본인의 권한을 강등시킬 수 없습니다.";
 
   private ExceptionMessage() {
   }

--- a/src/main/java/com/pororoz/istock/common/utils/message/ExceptionStatus.java
+++ b/src/main/java/com/pororoz/istock/common/utils/message/ExceptionStatus.java
@@ -14,6 +14,7 @@ public class ExceptionStatus {
   public static final String PRODUCT_NOT_FOUND = "PRODUCT_NOT_FOUND";
   public static final String DUPLICATE_BOM = "DUPLICATE_BOM_COMBINATION";
   public static final String BOM_NOT_FOUND = "BOM_NOT_FOUND";
+  public static final String SELF_DEMOTE_ROLE = "SELF_DEMOTE_ROLE";
 
   // Uncontrolled Range
   public static final String RUNTIME_ERROR = "RUNTIME_ERROR";

--- a/src/main/java/com/pororoz/istock/domain/user/controller/UserController.java
+++ b/src/main/java/com/pororoz/istock/domain/user/controller/UserController.java
@@ -52,9 +52,9 @@ public class UserController {
 
   private final UserService userService;
 
-  @Operation(summary = "delete user", description = "유저 삭제 API")
+  @Operation(summary = "put user", description = "유저 수정 API")
   @ApiResponses({
-      @ApiResponse(responseCode = "200", description = ResponseMessage.SAVE_USER,
+      @ApiResponse(responseCode = "200", description = ResponseMessage.UPDATE_USER,
           content = {@Content(schema = @Schema(implementation = DeleteUserResponseSwagger.class))}),
       @ApiResponse(responseCode = "400", description = ExceptionMessage.INVALID_PATH,
           content = {@Content(schema = @Schema(implementation = InvalidIDExceptionSwagger.class))}),
@@ -71,9 +71,9 @@ public class UserController {
         new ResultDTO<>(ResponseStatus.OK, ResponseMessage.UPDATE_USER, response));
   }
 
-  @Operation(summary = "put user", description = "유저 수정 API")
+  @Operation(summary = "delete user", description = "유저 삭제 API")
   @ApiResponses({
-      @ApiResponse(responseCode = "200", description = ResponseMessage.SAVE_USER,
+      @ApiResponse(responseCode = "200", description = ResponseMessage.DELETE_USER,
           content = {@Content(schema = @Schema(implementation = DeleteUserResponseSwagger.class))}),
       @ApiResponse(responseCode = "400", description = ExceptionMessage.INVALID_PATH,
           content = {

--- a/src/main/java/com/pororoz/istock/domain/user/exception/SelfDemoteRoleException.java
+++ b/src/main/java/com/pororoz/istock/domain/user/exception/SelfDemoteRoleException.java
@@ -1,0 +1,11 @@
+package com.pororoz.istock.domain.user.exception;
+
+import com.pororoz.istock.common.exception.CustomException;
+import com.pororoz.istock.common.exception.ErrorCode;
+
+public class SelfDemoteRoleException extends CustomException {
+
+  public SelfDemoteRoleException() {
+    super(ErrorCode.SELF_DEMOTE_ROLE);
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/user/service/UserServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.pororoz.istock.common.utils.Pagination;
+import com.pororoz.istock.domain.auth.dto.CustomUserDetailsDTO;
 import com.pororoz.istock.domain.user.dto.service.DeleteUserServiceRequest;
 import com.pororoz.istock.domain.user.dto.service.FindUserServiceRequest;
 import com.pororoz.istock.domain.user.dto.service.SaveUserServiceRequest;
@@ -17,6 +18,7 @@ import com.pororoz.istock.domain.user.dto.service.UserServiceResponse;
 import com.pororoz.istock.domain.user.entity.Role;
 import com.pororoz.istock.domain.user.entity.User;
 import com.pororoz.istock.domain.user.exception.RoleNotFoundException;
+import com.pororoz.istock.domain.user.exception.SelfDemoteRoleException;
 import com.pororoz.istock.domain.user.exception.UserNotFoundException;
 import com.pororoz.istock.domain.user.repository.RoleRepository;
 import com.pororoz.istock.domain.user.repository.UserRepository;
@@ -31,10 +33,18 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
 
 @ExtendWith(MockitoExtension.class)
 class UserServiceTest {
@@ -61,16 +71,22 @@ class UserServiceTest {
     private String newPassword;
     private String roleName;
     private String newRoleName;
-    private final Role role = Role.builder().roleName("ROLE_USER").build();
+    private final Role roleAdmin = Role.builder().roleName("ROLE_ADMIN").build();
+    private final Role roleUser = Role.builder().roleName("ROLE_USER").build();
 
     @BeforeEach
     void setup() {
       userId = 1L;
-      username = "test";
+      username = "user";
       password = "ab1234";
       newPassword = "abc123";
-      roleName = "ROLE_USER";
-      newRoleName = "ROLE_ADMIN";
+      roleName = "ROLE_ADMIN";
+      newRoleName = "ROLE_USER";
+
+      User admin = User.builder().id(2L).username("admin").password("admin").role(roleAdmin).build();
+      CustomUserDetailsDTO user = new CustomUserDetailsDTO(admin);
+      SecurityContext context = SecurityContextHolder.getContext();
+      context.setAuthentication(new UsernamePasswordAuthenticationToken(user.getUsername(), user.getPassword(), user.getAuthorities()));
     }
 
     @Nested
@@ -78,10 +94,10 @@ class UserServiceTest {
     class SuccessCase {
 
       @Test
+      @WithMockUser
       @DisplayName("존재하는 유저를 업데이트한다.")
       void updateUser() {
         // given
-        String encodedPassword = "newEncoded0987";
         UpdateUserServiceRequest updateUserServiceRequest = UpdateUserServiceRequest.builder()
             .userId(userId)
             .roleName(newRoleName)
@@ -92,18 +108,17 @@ class UserServiceTest {
             .id(userId)
             .username(username)
             .password(password)
-            .role(role)
+            .role(roleAdmin)
             .build();
 
         UserServiceResponse response = UserServiceResponse.builder()
             .userId(userId)
             .username(username)
-            .roleName(roleName)
+            .roleName(newRoleName)
             .build();
 
         // when
-        when(passwordEncoder.encode(newPassword)).thenReturn(encodedPassword);
-        when(roleRepository.findByRoleName(any())).thenReturn(Optional.of(role));
+        when(roleRepository.findByRoleName(any())).thenReturn(Optional.of(roleUser));
         when(userRepository.findById(userId)).thenReturn(Optional.of(targetUser));
         UserServiceResponse result = userService.updateUser(updateUserServiceRequest);
 
@@ -128,7 +143,7 @@ class UserServiceTest {
             .build();
 
         // when
-        when(roleRepository.findByRoleName(roleName)).thenReturn(Optional.of(role));
+        when(roleRepository.findByRoleName(roleName)).thenReturn(Optional.of(roleAdmin));
 
         // then
         assertThrows(UserNotFoundException.class,
@@ -150,6 +165,32 @@ class UserServiceTest {
 
         //then
         assertThrows(RoleNotFoundException.class,
+            () -> userService.updateUser(updateUserServiceRequest));
+      }
+
+      @Test
+      @DisplayName("자신의 role을 강등시키려고 하면 SelfDemoteException이 발생한다.")
+      void selfDemote() {
+        // given
+        UpdateUserServiceRequest updateUserServiceRequest = UpdateUserServiceRequest.builder()
+            .userId(2L)
+            .roleName(newRoleName)
+            .password(newPassword)
+            .build();
+
+        User targetUser = User.builder()
+            .id(2L)
+            .username("admin")
+            .password("admin")
+            .role(roleAdmin)
+            .build();
+
+        // when
+        when(roleRepository.findByRoleName(newRoleName)).thenReturn(Optional.of(roleUser));
+        when(userRepository.findById(2L)).thenReturn(Optional.of(targetUser));
+
+        //then
+        assertThrows(SelfDemoteRoleException.class,
             () -> userService.updateUser(updateUserServiceRequest));
       }
     }


### PR DESCRIPTION
## 개요
자신의 권한을 ADMIN에서 USER로 강등시킬 수 없다.

## 공유
- test를 보면 securityContextHolder 등을 직접 선언해서 사용하고 있는데, 어노테이션으로 만들어서 하는 방법이 있더라구요.
해당 로직을 더 사용할 곳이 있으면 어노테이션으로 만들어 보려고 하는데 사용되는 곳이 또 있을까요?

## 관련 이슈
- #58 