### PR TITLE
[Feature] logout api 구현

### DIFF
--- a/src/main/java/com/pororoz/istock/common/utils/message/ResponseMessage.java
+++ b/src/main/java/com/pororoz/istock/common/utils/message/ResponseMessage.java
@@ -3,6 +3,7 @@ package com.pororoz.istock.common.utils.message;
 public class ResponseMessage {
 
   public static final String LOGIN = "로그인";
+  public static final String LOGOUT = "로그아웃";
   public static final String SAVE_USER = "계정 생성";
   public static final String DELETE_USER = "계정 삭제";
   public static final String FIND_USER = "계정 조회";

--- a/src/main/java/com/pororoz/istock/domain/auth/controlloer/AuthController.java
+++ b/src/main/java/com/pororoz/istock/domain/auth/controlloer/AuthController.java
@@ -2,13 +2,19 @@ package com.pororoz.istock.domain.auth.controlloer;
 
 import com.pororoz.istock.common.utils.message.ExceptionMessage;
 import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.domain.auth.dto.request.LoginRequest;
+import com.pororoz.istock.domain.auth.swagger.response.LoginResponseSwagger;
+import com.pororoz.istock.domain.auth.swagger.response.LogoutResponseSwagger;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,11 +26,19 @@ public class AuthController {
 
   @Operation(summary = "login", description = "유저 로그인")
   @ApiResponses({
-      @ApiResponse(responseCode = "200", description = ResponseMessage.LOGIN),
-      @ApiResponse(responseCode = "401", description = ExceptionMessage.UNAUTHORIZED)
-  })
+      @ApiResponse(responseCode = "200", description = ResponseMessage.LOGIN, content = {
+          @Content(schema = @Schema(implementation = LoginResponseSwagger.class))}),
+      @ApiResponse(responseCode = "401", description = ExceptionMessage.UNAUTHORIZED, content = @Content)})
   @PostMapping("/login")
-  public void login() {
+  public void login(@RequestBody LoginRequest request) {
+  }
+
+  @Operation(summary = "logout", description = "유저 로그아웃")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = ResponseMessage.LOGOUT, content = {
+          @Content(schema = @Schema(implementation = LogoutResponseSwagger.class))})})
+  @PostMapping("/logout")
+  public void logout() {
   }
 
   @GetMapping("/admin") // 권한 확인용 api

--- a/src/main/java/com/pororoz/istock/domain/auth/dto/request/LoginRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/auth/dto/request/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.pororoz.istock.domain.auth.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
@@ -13,10 +14,13 @@ import lombok.NoArgsConstructor;
 @Data
 public class LoginRequest {
 
+
+  @Schema(description = "아이디", example = "username")
   @Size(min = 2)
   @NotBlank
   private String username;
 
+  @Schema(description = "비밀번호", example = "1q2w3e4r")
   @Size(min = 2)
   @NotBlank
   private String password;

--- a/src/main/java/com/pororoz/istock/domain/auth/handler/CustomAuthenticationSuccessHandler.java
+++ b/src/main/java/com/pororoz/istock/domain/auth/handler/CustomAuthenticationSuccessHandler.java
@@ -29,10 +29,11 @@ public class CustomAuthenticationSuccessHandler implements AuthenticationSuccess
 
     response.setHeader("content-type", "application/json");
     response.setCharacterEncoding("UTF-8");
+    response.setStatus(HttpServletResponse.SC_OK);
     LoginResponse loginResponse = LoginResponse.builder()
         .username((String) authentication.getPrincipal())
         .roleName(authentication.getAuthorities().iterator().next().toString()).build();
-    ResponseEntity responseEntity = ResponseEntity.ok(
+    ResponseEntity<ResultDTO<LoginResponse>> responseEntity = ResponseEntity.ok(
         new ResultDTO<>(ResponseStatus.OK, ResponseMessage.LOGIN, loginResponse));
     String result = objectMapper.writeValueAsString(responseEntity.getBody());
     response.getWriter().write(result);

--- a/src/main/java/com/pororoz/istock/domain/auth/swagger/response/LoginResponseSwagger.java
+++ b/src/main/java/com/pororoz/istock/domain/auth/swagger/response/LoginResponseSwagger.java
@@ -1,0 +1,19 @@
+package com.pororoz.istock.domain.auth.swagger.response;
+
+import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.auth.dto.response.LoginResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class LoginResponseSwagger {
+
+  @Schema(description = "Result Code", example = ResponseStatus.OK)
+  private String status;
+
+  @Schema(description = "Message", example = ResponseMessage.LOGIN)
+  private String message;
+
+  private LoginResponse data;
+}

--- a/src/main/java/com/pororoz/istock/domain/auth/swagger/response/LogoutResponseSwagger.java
+++ b/src/main/java/com/pororoz/istock/domain/auth/swagger/response/LogoutResponseSwagger.java
@@ -1,0 +1,16 @@
+package com.pororoz.istock.domain.auth.swagger.response;
+
+import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class LogoutResponseSwagger {
+
+  @Schema(description = "Result Code", example = ResponseStatus.OK)
+  private String status;
+
+  @Schema(description = "Message", example = ResponseMessage.LOGOUT)
+  private String message;
+}


### PR DESCRIPTION
## 개요
- logout API 구현
## 세부 내용
- query
  - POST `/api/v1/auth/logout`
- response
```
{
	status: "OK",
	message: "로그아웃"
}
```

- login, logout swagger 작성
## 공유

- 고민과 질문

## 관련 이슈

- #71 