### PR TITLE
[Feature] BOM GET API에 productId 필드 추가

### DIFF
--- a/src/main/java/com/pororoz/istock/domain/bom/dto/response/FindBomResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/bom/dto/response/FindBomResponse.java
@@ -12,6 +12,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @NoArgsConstructor
 public class FindBomResponse {
+
   @Schema(description = "bom 아이디", example = "1")
   private Long bomId;
 
@@ -32,5 +33,9 @@ public class FindBomResponse {
 
   @Schema(description = "수정 시간", example = "2023-01-01 00:00:01")
   private String updatedAt;
+
+  @Schema(description = "제품 아이디", example = "2")
+  private Long productId;
+
   private PartResponse part;
 }

--- a/src/main/java/com/pororoz/istock/domain/bom/dto/service/FindBomServiceResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/bom/dto/service/FindBomServiceResponse.java
@@ -22,6 +22,7 @@ public class FindBomServiceResponse {
   private String memo;
   private String createdAt;
   private String updatedAt;
+  private Long productId;
   private PartResponse part;
 
   static public FindBomServiceResponse of(Bom bom) {
@@ -33,6 +34,7 @@ public class FindBomServiceResponse {
         .memo(bom.getMemo())
         .createdAt(TimeEntity.formatTime(bom.getCreatedAt()))
         .updatedAt(TimeEntity.formatTime(bom.getUpdatedAt()))
+        .productId(bom.getProduct().getId())
         .part(PartResponse.of(bom.getPart()))
         .build();
   }
@@ -46,6 +48,7 @@ public class FindBomServiceResponse {
         .memo(memo)
         .createdAt(createdAt)
         .updatedAt(updatedAt)
+        .productId(productId)
         .part(part)
         .build();
   }

--- a/src/test/java/com/pororoz/istock/domain/bom/BomIntegrationTest.java
+++ b/src/test/java/com/pororoz/istock/domain/bom/BomIntegrationTest.java
@@ -226,6 +226,7 @@ public class BomIntegrationTest extends IntegrationTest {
               .part(PartResponse.of(bom.getPart()))
               .createdAt(TimeEntity.formatTime(bom.getCreatedAt()))
               .updatedAt(TimeEntity.formatTime(bom.getUpdatedAt()))
+              .productId(bom.getProduct().getId())
               .build());
         }
         PageResponse<FindBomResponse> response = new PageResponse<>(
@@ -262,6 +263,7 @@ public class BomIntegrationTest extends IntegrationTest {
               .part(PartResponse.of(bom.getPart()))
               .createdAt(TimeEntity.formatTime(bom.getCreatedAt()))
               .updatedAt(TimeEntity.formatTime(bom.getUpdatedAt()))
+              .productId(bom.getProduct().getId())
               .build());
         }
         PageResponse<FindBomResponse> response = new PageResponse<>(

--- a/src/test/java/com/pororoz/istock/domain/bom/controller/BomControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/bom/controller/BomControllerTest.java
@@ -101,6 +101,7 @@ class BomControllerTest extends ControllerTest {
             .memo(memo)
             .createdAt(now)
             .updatedAt(now)
+            .productId(productId)
             .part(part1)
             .build();
         FindBomServiceResponse serviceResponse2 = FindBomServiceResponse.builder()
@@ -111,6 +112,7 @@ class BomControllerTest extends ControllerTest {
             .memo(memo)
             .createdAt(now)
             .updatedAt(now)
+            .productId(productId)
             .part(part2)
             .build();
         Page<FindBomServiceResponse> dtoPage =
@@ -128,6 +130,7 @@ class BomControllerTest extends ControllerTest {
             .memo(memo)
             .createdAt(now)
             .updatedAt(now)
+            .productId(productId)
             .part(part1)
             .build();
         FindBomResponse findBomResponse2 = FindBomResponse.builder()
@@ -138,6 +141,7 @@ class BomControllerTest extends ControllerTest {
             .memo(memo)
             .createdAt(now)
             .updatedAt(now)
+            .productId(productId)
             .part(part2)
             .build();
         PageResponse<FindBomResponse> response =


### PR DESCRIPTION
## 개요
BOM GET API에 productId 필드 추가

## 세부 내용
findBom 관련 response dto에 productId 추가

## 공유
회의 당시에는 정신 없어서 생각이 안 났는데, productId는 쿼리 파라미터의 productId랑 같은게 아닌가?
contents list안의 모든 productId는 같은 값일텐데, 이 정보가 필요한 이유는 ts 타입에 값을 편하게 할당하기 위함인가

- 고민과 질문

## 관련 이슈

- #91 