### PR TITLE
[Feature] 제품 출고 취소 API

### DIFF
--- a/src/main/java/com/pororoz/istock/common/utils/message/ResponseMessage.java
+++ b/src/main/java/com/pororoz/istock/common/utils/message/ResponseMessage.java
@@ -35,6 +35,7 @@ public class ResponseMessage {
   public static final String CONFIRM_SUB_ASSY_PURCHASE = "Sub Assy 구매 확정";
   public static final String CANCEL_SUB_ASSY_PURCHASE = "Sub Assy 구매 취소";
   public static final String OUTBOUND_CONFIRM = "제품 출고 확정";
+  public static final String OUTBOUND_CANCEL = "제품 출고 취소";
 
   private ResponseMessage() {
   }

--- a/src/main/java/com/pororoz/istock/domain/outbound/controller/OutboundController.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/controller/OutboundController.java
@@ -14,6 +14,7 @@ import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceResponse;
 import com.pororoz.istock.domain.outbound.service.OutboundService;
 import com.pororoz.istock.domain.outbound.swagger.exception.ProductIdNotPositiveExceptionSwagger;
 import com.pororoz.istock.domain.outbound.swagger.exception.ProductIoIdNotPositiveExceptionSwagger;
+import com.pororoz.istock.domain.outbound.swagger.response.OutboundCancelResponseSwagger;
 import com.pororoz.istock.domain.outbound.swagger.response.OutboundConfirmResponseSwagger;
 import com.pororoz.istock.domain.outbound.swagger.response.OutboundResponseSwagger;
 import com.pororoz.istock.domain.product.exception.ProductNotFoundException;
@@ -91,8 +92,8 @@ public class OutboundController {
 
   @Operation(summary = "outbound cancel", description = "제품 출고 취소")
   @ApiResponses({
-      @ApiResponse(responseCode = "200", description = ResponseMessage.OUTBOUND_CONFIRM, content = {
-          @Content(schema = @Schema(implementation = OutboundConfirmResponseSwagger.class))}),
+      @ApiResponse(responseCode = "200", description = ResponseMessage.OUTBOUND_CANCEL, content = {
+          @Content(schema = @Schema(implementation = OutboundCancelResponseSwagger.class))}),
       @ApiResponse(responseCode = "400", description = ExceptionMessage.BAD_REQUEST, content = {
           @Content(schema = @Schema(implementation = ProductIoIdNotPositiveExceptionSwagger.class))}),
       @ApiResponse(responseCode = "403", description = ExceptionMessage.FORBIDDEN, content = {

--- a/src/main/java/com/pororoz/istock/domain/outbound/controller/OutboundController.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/controller/OutboundController.java
@@ -58,7 +58,7 @@ public class OutboundController {
   })
   @PostMapping("/products/{productId}/waiting")
   public ResponseEntity<ResultDTO<OutboundResponse>> outbound(
-      @PathVariable("productId") @NotNull @Positive Long productId,
+      @PathVariable("productId") @NotNull @Positive long productId,
       @Valid @RequestBody OutboundRequest request
   ) {
     OutboundServiceResponse serviceDto = outboundService.outbound(request.toService(productId));
@@ -80,12 +80,34 @@ public class OutboundController {
   })
   @PostMapping("/product-io/{productIoId}/confirm")
   public ResponseEntity<ResultDTO<OutboundConfirmResponse>> outboundConfirm(
-      @PathVariable("productIoId") @NotNull @Positive Long productIoId
+      @PathVariable("productIoId") @NotNull @Positive long productIoId
   ) {
     OutboundConfirmServiceResponse serviceDto = outboundService.outboundConfirm(
         OutboundConfirmServiceRequest.builder().productIoId(productIoId).build());
     OutboundConfirmResponse response = serviceDto.toResponse();
     return ResponseEntity.ok(
         new ResultDTO<>(ResponseStatus.OK, ResponseMessage.OUTBOUND_CONFIRM, response));
+  }
+
+  @Operation(summary = "outbound cancel", description = "제품 출고 취소")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = ResponseMessage.OUTBOUND_CONFIRM, content = {
+          @Content(schema = @Schema(implementation = OutboundConfirmResponseSwagger.class))}),
+      @ApiResponse(responseCode = "400", description = ExceptionMessage.BAD_REQUEST, content = {
+          @Content(schema = @Schema(implementation = ProductIoIdNotPositiveExceptionSwagger.class))}),
+      @ApiResponse(responseCode = "403", description = ExceptionMessage.FORBIDDEN, content = {
+          @Content(schema = @Schema(implementation = AccessForbiddenSwagger.class))}),
+      @ApiResponse(responseCode = "404", description = ExceptionMessage.PRODUCT_IO_NOT_FOUND, content = {
+          @Content(schema = @Schema(implementation = ProductIoNotFoundExceptionSwagger.class))}),
+  })
+  @PostMapping("/product-io/{productIoId}/cancel")
+  public ResponseEntity<ResultDTO<OutboundConfirmResponse>> outboundCancel(
+      @PathVariable("productIoId") @NotNull @Positive long productIoId
+  ) {
+    OutboundConfirmServiceResponse serviceDto = outboundService.outboundCancel(
+        OutboundConfirmServiceRequest.builder().productIoId(productIoId).build());
+    OutboundConfirmResponse response = serviceDto.toResponse();
+    return ResponseEntity.ok(
+        new ResultDTO<>(ResponseStatus.OK, ResponseMessage.OUTBOUND_CANCEL, response));
   }
 }

--- a/src/main/java/com/pororoz/istock/domain/outbound/service/OutboundService.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/service/OutboundService.java
@@ -50,6 +50,9 @@ public class OutboundService {
   public OutboundConfirmServiceResponse outboundCancel(OutboundConfirmServiceRequest request) {
     ProductIo productIo = productIoRepository.findById(request.getProductIoId())
         .orElseThrow(ProductIoNotFoundException::new);
+    Product product = productRepository.findById(productIo.getProduct().getId())
+            .orElseThrow(ProductNotFoundException::new);
+    product.addStock(productIo.getQuantity());
     productIo.cancelOutbound();
     return OutboundConfirmServiceResponse.of(productIo);
   }

--- a/src/main/java/com/pororoz/istock/domain/outbound/service/OutboundService.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/service/OutboundService.java
@@ -46,4 +46,11 @@ public class OutboundService {
     productIo.confirmOutbound();
     return OutboundConfirmServiceResponse.of(productIo);
   }
+
+  public OutboundConfirmServiceResponse outboundCancel(OutboundConfirmServiceRequest request) {
+    ProductIo productIo = productIoRepository.findById(request.getProductIoId())
+        .orElseThrow(ProductIoNotFoundException::new);
+    productIo.cancelOutbound();
+    return OutboundConfirmServiceResponse.of(productIo);
+  }
 }

--- a/src/main/java/com/pororoz/istock/domain/outbound/swagger/response/OutboundCancelResponseSwagger.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/swagger/response/OutboundCancelResponseSwagger.java
@@ -1,0 +1,19 @@
+package com.pororoz.istock.domain.outbound.swagger.response;
+
+import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.outbound.dto.response.OutboundConfirmResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class OutboundCancelResponseSwagger {
+
+  @Schema(description = "Result Code", example = ResponseStatus.OK)
+  private String status;
+
+  @Schema(description = "Message", example = ResponseMessage.OUTBOUND_CANCEL)
+  private String message;
+
+  private OutboundConfirmResponse data;
+}

--- a/src/test/java/com/pororoz/istock/domain/outbound/OutboundIntegrationTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/OutboundIntegrationTest.java
@@ -281,4 +281,136 @@ public class OutboundIntegrationTest extends IntegrationTest {
       }
     }
   }
+
+  @Nested
+  @DisplayName("POST /api/v1/outbounds/product-io/{productIoId}/cancel - 제품 출고 취소")
+  class OutboundCancel {
+
+    String url(Long productIoId) {
+      return "http://localhost:8080/v1/outbounds/product-io/" + productIoId + "/cancel";
+    }
+
+    final Long productId = 1L;
+    final Long productIoId = 1L;
+    final Long productQuantity = 50L;
+    final Long productIoQuantity = 100L;
+    final String name = "product1";
+    final String number = "GS-IH-01";
+    final String companyName = "company name";
+    final String codeNumber = "code number";
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCase {
+      @BeforeEach
+      void setup() {
+        Category category = categoryRepository.save(
+            Category.builder().categoryName("카테고리").build());
+        Product product = productRepository.save(
+            Product.builder()
+                .productName(name)
+                .productNumber(number)
+                .codeNumber(codeNumber)
+                .companyName(companyName)
+                .stock(productQuantity)
+                .category(category)
+                .build());
+        productIoRepository.save(ProductIo.builder()
+            .status(ProductStatus.출고대기)
+            .quantity(productIoQuantity)
+            .product(product)
+            .build());
+      }
+
+      @Test
+      @WithMockUser(roles = "USER")
+      @DisplayName("productIoId, productId와 quantity가 포함된 정보를 제공하면 200 OK와 data를 전달한다.")
+      void outboundConfirm() throws Exception {
+        // given
+
+        // when
+        ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
+
+        // then
+        OutboundConfirmResponse response = OutboundConfirmResponse.builder()
+            .productIoId(productIoId)
+            .productId(productId)
+            .quantity(productIoQuantity)
+            .build();
+        actions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(ResponseMessage.OUTBOUND_CANCEL))
+            .andExpect(jsonPath("$.data", equalTo(asParsedJson(response))))
+            .andDo(print());
+
+        // productIo의 status가 변경됐는지 확인
+        ProductIo changedProductIo = productIoRepository.findById(productIoId)
+            .orElseThrow(ProductIoNotFoundException::new);
+        assertThat(changedProductIo.getStatus()).isEqualTo(ProductStatus.출고취소);
+      }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailCase {
+      @Test
+      @WithMockUser(roles = "ADMIN")
+      @DisplayName("productIo의 status가 출고대기 상태가 아니라면 400 BadRequest Error를 발생시킨다.")
+      void productIoStatusError() throws Exception {
+        // given
+        Category category = categoryRepository.save(
+            Category.builder().categoryName("카테고리").build());
+        Product product = productRepository.save(
+            Product.builder()
+                .productName(name)
+                .productNumber(number)
+                .codeNumber(codeNumber)
+                .companyName(companyName)
+                .stock(productQuantity)
+                .category(category)
+                .build());
+        productIoRepository.save(ProductIo.builder()
+            .status(ProductStatus.출고완료)
+            .quantity(productIoQuantity)
+            .product(product)
+            .build());
+
+        // when
+        ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
+
+        // then
+        actions.andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.status").value(ExceptionStatus.CHANGE_OUTBOUND_STATUS))
+            .andDo(print());
+      }
+
+      @Test
+      @WithMockUser(roles = "ADMIN")
+      @DisplayName("productIo가 존재하지 않으면 403 Not Found Error를 발생시킨다.")
+      void productIoNotFound() throws Exception {
+        // given
+
+        // when
+        ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
+
+        // then
+        actions.andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.status").value(ExceptionStatus.PRODUCT_IO_NOT_FOUND))
+            .andExpect(jsonPath("$.message").value(ExceptionMessage.PRODUCT_IO_NOT_FOUND));
+      }
+
+      @Test
+      @DisplayName("인증되지 않은 사용자가 접근하면 FORBIDDEN을 반환한다.")
+      void forbidden() throws Exception {
+        //given
+
+        //when
+        ResultActions actions = getResultActions(url(productId), HttpMethod.POST);
+
+        //then
+        actions.andExpect(status().isForbidden())
+            .andDo(print());
+      }
+    }
+  }
 }

--- a/src/test/java/com/pororoz/istock/domain/outbound/controller/OutboundControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/controller/OutboundControllerTest.java
@@ -220,7 +220,18 @@ class OutboundControllerTest extends ControllerTest {
     @Nested
     @DisplayName("실패 케이스")
     class FailCase {
+      @Test
+      @DisplayName("productIoId값이 0이하면 예외처리를 한다.")
+      void productIoIdNotPositive() throws Exception {
+        // given
 
+        // when
+        ResultActions actions = getResultActions(url(-1L), HttpMethod.POST);
+
+        // then
+        actions.andExpect(status().isBadRequest())
+            .andDo(print());
+      }
     }
   }
 }

--- a/src/test/java/com/pororoz/istock/domain/outbound/controller/OutboundControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/controller/OutboundControllerTest.java
@@ -176,4 +176,51 @@ class OutboundControllerTest extends ControllerTest {
       }
     }
   }
+
+  @Nested
+  @DisplayName("제품 출고 취소 API")
+  class OutboundCancel {
+
+    String url(long productIoId) {
+      return "http://localhost:8080/v1/outbounds/product-io/" + productIoId + "/cancel";
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCase {
+      @Test
+      @DisplayName("제품 출고 취소를 하면 200 OK값과 해당 productIo와 product에 대한 정보를 제공한다.")
+      void cancelOutbound() throws Exception {
+        // given
+        OutboundConfirmServiceResponse serviceResponse = OutboundConfirmServiceResponse.builder()
+            .productIoId(productIoId)
+            .productId(productId)
+            .quantity(quantity)
+            .build();
+
+        // when
+        when(outboundService.outboundCancel(any(OutboundConfirmServiceRequest.class)))
+            .thenReturn(serviceResponse);
+        ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
+
+        // then
+        OutboundConfirmResponse response = OutboundConfirmResponse.builder()
+            .productIoId(productIoId)
+            .productId(productId)
+            .quantity(quantity)
+            .build();
+        actions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(ResponseMessage.OUTBOUND_CANCEL))
+            .andExpect(jsonPath("$.data", equalTo(asParsedJson(response))))
+            .andDo(print());
+      }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailCase {
+
+    }
+  }
 }

--- a/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
@@ -227,7 +227,40 @@ class OutboundServiceTest {
     @Nested
     @DisplayName("실패 케이스")
     class FailCase {
+      @Test
+      @DisplayName("productIo가 존재하지 않으면 에러가 발생한다.")
+      void notFoundProduct() {
+        // given
+        // when
+        when(productIoRepository.findById(anyLong())).thenReturn(Optional.empty());
 
+        // then
+        assertThrows(ProductIoNotFoundException.class,
+            () -> outboundService.outboundConfirm(request));
+      }
+
+      @Test
+      @DisplayName("ProductIo의 status의 값이 출고대기가 아니라면 Exception이 발생한다.")
+      void productIoStatusError() {
+        // given
+        Product product = Product.builder()
+            .id(productId)
+            .stock(50)
+            .build();
+        ProductIo productIo = ProductIo.builder()
+            .id(productIoId)
+            .status(ProductStatus.출고완료)
+            .quantity(quantity)
+            .product(product)
+            .build();
+
+        // when
+        when(productIoRepository.findById(productIoId)).thenReturn(Optional.of(productIo));
+
+        // then
+        assertThrows(ChangeOutboundStatusException.class,
+            () -> outboundService.outboundConfirm(request));
+      }
     }
   }
 }

--- a/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
@@ -148,7 +148,7 @@ class OutboundServiceTest {
 
       @Test
       @DisplayName("productIo가 존재하지 않으면 에러가 발생한다.")
-      void notFoundProduct() {
+      void notFoundProductIo() {
         // given
         // when
         when(productIoRepository.findById(anyLong())).thenReturn(Optional.empty());
@@ -217,6 +217,7 @@ class OutboundServiceTest {
 
         // when
         when(productIoRepository.findById(anyLong())).thenReturn(Optional.of(productIo));
+        when(productRepository.findById(anyLong())).thenReturn(Optional.of(product));
         OutboundConfirmServiceResponse result = outboundService.outboundCancel(request);
 
         // then
@@ -229,14 +230,38 @@ class OutboundServiceTest {
     class FailCase {
       @Test
       @DisplayName("productIo가 존재하지 않으면 에러가 발생한다.")
-      void notFoundProduct() {
+      void notFoundProductIo() {
         // given
         // when
         when(productIoRepository.findById(anyLong())).thenReturn(Optional.empty());
 
         // then
         assertThrows(ProductIoNotFoundException.class,
-            () -> outboundService.outboundConfirm(request));
+            () -> outboundService.outboundCancel(request));
+      }
+
+      @Test
+      @DisplayName("product가 존재하지 않으면 에러가 발생한다.")
+      void notFoundProduct() {
+        // given
+        Product product = Product.builder()
+            .id(productId)
+            .stock(50)
+            .build();
+        ProductIo productIo = ProductIo.builder()
+            .id(productIoId)
+            .status(ProductStatus.출고대기)
+            .quantity(quantity)
+            .product(product)
+            .build();
+
+        // when
+        when(productIoRepository.findById(anyLong())).thenReturn(Optional.of(productIo));
+        when(productRepository.findById(anyLong())).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(ProductNotFoundException.class,
+            () -> outboundService.outboundCancel(request));
       }
 
       @Test
@@ -256,10 +281,11 @@ class OutboundServiceTest {
 
         // when
         when(productIoRepository.findById(productIoId)).thenReturn(Optional.of(productIo));
+        when(productRepository.findById(anyLong())).thenReturn(Optional.of(product));
 
         // then
         assertThrows(ChangeOutboundStatusException.class,
-            () -> outboundService.outboundConfirm(request));
+            () -> outboundService.outboundCancel(request));
       }
     }
   }

--- a/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
@@ -182,4 +182,52 @@ class OutboundServiceTest {
       }
     }
   }
+
+  @Nested
+  @DisplayName("제품 출고 취소")
+  class CancelOutbound {
+
+    OutboundConfirmServiceRequest request = OutboundConfirmServiceRequest.builder()
+        .productIoId(productIoId)
+        .build();
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCase {
+
+      @Test
+      @DisplayName("제품 출고 취소 로직을 처리한다.")
+      void cancelOutbound() {
+        // given
+        Product product = Product.builder()
+            .id(productId)
+            .stock(50)
+            .build();
+        ProductIo productIo = ProductIo.builder()
+            .id(productIoId)
+            .status(ProductStatus.출고대기)
+            .quantity(quantity)
+            .product(product)
+            .build();
+        OutboundConfirmServiceResponse response = OutboundConfirmServiceResponse.builder()
+            .productIoId(productIoId)
+            .productId(productId)
+            .quantity(quantity)
+            .build();
+
+        // when
+        when(productIoRepository.findById(anyLong())).thenReturn(Optional.of(productIo));
+        OutboundConfirmServiceResponse result = outboundService.outboundCancel(request);
+
+        // then
+        assertThat(result).usingRecursiveComparison().isEqualTo(response);
+      }
+    }
+
+    @Nested
+    @DisplayName("실패 케이스")
+    class FailCase {
+
+    }
+  }
 }


### PR DESCRIPTION
## 개요

- 제품 출고 취소 API

## 세부 내용

<ul>
<li>
<p>시스템에 등록된 Product의 출고 대기 내역을 출고 취소 상태로 만드는 기능</p>
<ul>
<li>Product I/O table의 출고 대기 항목을 출고 취소 상태로 변경</li>
<li>Product table의 stock column을 파트 소요량만큼 증가 (롤백)</li>
</ul>
</li>
<li>
<p><strong>query</strong></p>


POST | /api/v1/outbounds/product-io/{productIoId}/cancel
-- | --



</li>
<li>
<p><strong>response</strong></p>
</li>
</ul>
<pre><code class="language-json">{
	status: &quot;OK&quot;,
	message: &quot;제품 출고 취소&quot;,
	data: {
    productIoId: 7777,
	  productId: 7,
		quantity: 100
	}
}
</code></pre>


## 관련 이슈

- #99 