### PR TITLE
[Refactor] 제품 출고 dto 네이밍 변경

### DIFF
--- a/src/main/java/com/pororoz/istock/domain/outbound/controller/OutboundController.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/controller/OutboundController.java
@@ -6,10 +6,10 @@ import com.pororoz.istock.common.utils.message.ExceptionMessage;
 import com.pororoz.istock.common.utils.message.ResponseMessage;
 import com.pororoz.istock.common.utils.message.ResponseStatus;
 import com.pororoz.istock.domain.outbound.dto.request.OutboundRequest;
-import com.pororoz.istock.domain.outbound.dto.response.OutboundConfirmResponse;
+import com.pororoz.istock.domain.outbound.dto.response.OutboundUpdateResponse;
 import com.pororoz.istock.domain.outbound.dto.response.OutboundResponse;
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceRequest;
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceResponse;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceRequest;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceResponse;
 import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceResponse;
 import com.pororoz.istock.domain.outbound.service.OutboundService;
 import com.pororoz.istock.domain.outbound.swagger.exception.ProductIdNotPositiveExceptionSwagger;
@@ -80,12 +80,12 @@ public class OutboundController {
           @Content(schema = @Schema(implementation = ProductIoNotFoundExceptionSwagger.class))}),
   })
   @PostMapping("/product-io/{productIoId}/confirm")
-  public ResponseEntity<ResultDTO<OutboundConfirmResponse>> outboundConfirm(
+  public ResponseEntity<ResultDTO<OutboundUpdateResponse>> outboundConfirm(
       @PathVariable("productIoId") @NotNull @Positive long productIoId
   ) {
-    OutboundConfirmServiceResponse serviceDto = outboundService.outboundConfirm(
-        OutboundConfirmServiceRequest.builder().productIoId(productIoId).build());
-    OutboundConfirmResponse response = serviceDto.toResponse();
+    OutboundUpdateServiceResponse serviceDto = outboundService.outboundConfirm(
+        OutboundUpdateServiceRequest.builder().productIoId(productIoId).build());
+    OutboundUpdateResponse response = serviceDto.toResponse();
     return ResponseEntity.ok(
         new ResultDTO<>(ResponseStatus.OK, ResponseMessage.OUTBOUND_CONFIRM, response));
   }
@@ -102,12 +102,12 @@ public class OutboundController {
           @Content(schema = @Schema(implementation = ProductIoNotFoundExceptionSwagger.class))}),
   })
   @PostMapping("/product-io/{productIoId}/cancel")
-  public ResponseEntity<ResultDTO<OutboundConfirmResponse>> outboundCancel(
+  public ResponseEntity<ResultDTO<OutboundUpdateResponse>> outboundCancel(
       @PathVariable("productIoId") @NotNull @Positive long productIoId
   ) {
-    OutboundConfirmServiceResponse serviceDto = outboundService.outboundCancel(
-        OutboundConfirmServiceRequest.builder().productIoId(productIoId).build());
-    OutboundConfirmResponse response = serviceDto.toResponse();
+    OutboundUpdateServiceResponse serviceDto = outboundService.outboundCancel(
+        OutboundUpdateServiceRequest.builder().productIoId(productIoId).build());
+    OutboundUpdateResponse response = serviceDto.toResponse();
     return ResponseEntity.ok(
         new ResultDTO<>(ResponseStatus.OK, ResponseMessage.OUTBOUND_CANCEL, response));
   }

--- a/src/main/java/com/pororoz/istock/domain/outbound/dto/response/OutboundUpdateResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/dto/response/OutboundUpdateResponse.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class OutboundConfirmResponse {
+public class OutboundUpdateResponse {
 
   @Schema(description = "제품 I/O 아이디", example = "10")
   private Long productIoId;

--- a/src/main/java/com/pororoz/istock/domain/outbound/dto/service/OutboundUpdateServiceRequest.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/dto/service/OutboundUpdateServiceRequest.java
@@ -5,6 +5,6 @@ import lombok.Getter;
 
 @Builder
 @Getter
-public class OutboundConfirmServiceRequest {
+public class OutboundUpdateServiceRequest {
   private Long productIoId;
 }

--- a/src/main/java/com/pororoz/istock/domain/outbound/dto/service/OutboundUpdateServiceResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/dto/service/OutboundUpdateServiceResponse.java
@@ -1,27 +1,27 @@
 package com.pororoz.istock.domain.outbound.dto.service;
 
-import com.pororoz.istock.domain.outbound.dto.response.OutboundConfirmResponse;
+import com.pororoz.istock.domain.outbound.dto.response.OutboundUpdateResponse;
 import com.pororoz.istock.domain.product.entity.ProductIo;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
-public class OutboundConfirmServiceResponse {
+public class OutboundUpdateServiceResponse {
   private Long productIoId;
   private Long productId;
   private Long quantity;
 
-  public static OutboundConfirmServiceResponse of(ProductIo productIo) {
-    return OutboundConfirmServiceResponse.builder()
+  public static OutboundUpdateServiceResponse of(ProductIo productIo) {
+    return OutboundUpdateServiceResponse.builder()
         .productIoId(productIo.getId())
         .productId(productIo.getProduct().getId())
         .quantity(productIo.getQuantity())
         .build();
   }
 
-  public OutboundConfirmResponse toResponse() {
-    return OutboundConfirmResponse.builder()
+  public OutboundUpdateResponse toResponse() {
+    return OutboundUpdateResponse.builder()
         .productIoId(productIoId)
         .productId(productId)
         .quantity(quantity)

--- a/src/main/java/com/pororoz/istock/domain/outbound/service/OutboundService.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/service/OutboundService.java
@@ -1,7 +1,7 @@
 package com.pororoz.istock.domain.outbound.service;
 
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceRequest;
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceResponse;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceRequest;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceResponse;
 import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceRequest;
 import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceResponse;
 import com.pororoz.istock.domain.product.entity.Product;
@@ -40,20 +40,20 @@ public class OutboundService {
     return productIoRepository.save(productIo);
   }
 
-  public OutboundConfirmServiceResponse outboundConfirm(OutboundConfirmServiceRequest request) {
+  public OutboundUpdateServiceResponse outboundConfirm(OutboundUpdateServiceRequest request) {
     ProductIo productIo = productIoRepository.findById(request.getProductIoId())
         .orElseThrow(ProductIoNotFoundException::new);
     productIo.confirmOutbound();
-    return OutboundConfirmServiceResponse.of(productIo);
+    return OutboundUpdateServiceResponse.of(productIo);
   }
 
-  public OutboundConfirmServiceResponse outboundCancel(OutboundConfirmServiceRequest request) {
+  public OutboundUpdateServiceResponse outboundCancel(OutboundUpdateServiceRequest request) {
     ProductIo productIo = productIoRepository.findById(request.getProductIoId())
         .orElseThrow(ProductIoNotFoundException::new);
     Product product = productRepository.findById(productIo.getProduct().getId())
             .orElseThrow(ProductNotFoundException::new);
     product.addStock(productIo.getQuantity());
     productIo.cancelOutbound();
-    return OutboundConfirmServiceResponse.of(productIo);
+    return OutboundUpdateServiceResponse.of(productIo);
   }
 }

--- a/src/main/java/com/pororoz/istock/domain/outbound/swagger/response/OutboundCancelResponseSwagger.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/swagger/response/OutboundCancelResponseSwagger.java
@@ -2,7 +2,7 @@ package com.pororoz.istock.domain.outbound.swagger.response;
 
 import com.pororoz.istock.common.utils.message.ResponseMessage;
 import com.pororoz.istock.common.utils.message.ResponseStatus;
-import com.pororoz.istock.domain.outbound.dto.response.OutboundConfirmResponse;
+import com.pororoz.istock.domain.outbound.dto.response.OutboundUpdateResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -15,5 +15,5 @@ public class OutboundCancelResponseSwagger {
   @Schema(description = "Message", example = ResponseMessage.OUTBOUND_CANCEL)
   private String message;
 
-  private OutboundConfirmResponse data;
+  private OutboundUpdateResponse data;
 }

--- a/src/main/java/com/pororoz/istock/domain/outbound/swagger/response/OutboundConfirmResponseSwagger.java
+++ b/src/main/java/com/pororoz/istock/domain/outbound/swagger/response/OutboundConfirmResponseSwagger.java
@@ -2,7 +2,7 @@ package com.pororoz.istock.domain.outbound.swagger.response;
 
 import com.pororoz.istock.common.utils.message.ResponseMessage;
 import com.pororoz.istock.common.utils.message.ResponseStatus;
-import com.pororoz.istock.domain.outbound.dto.response.OutboundConfirmResponse;
+import com.pororoz.istock.domain.outbound.dto.response.OutboundUpdateResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -15,5 +15,5 @@ public class OutboundConfirmResponseSwagger {
   @Schema(description = "Message", example = ResponseMessage.OUTBOUND_CONFIRM)
   private String message;
 
-  private OutboundConfirmResponse data;
+  private OutboundUpdateResponse data;
 }

--- a/src/test/java/com/pororoz/istock/domain/outbound/OutboundIntegrationTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/OutboundIntegrationTest.java
@@ -14,7 +14,7 @@ import com.pororoz.istock.common.utils.message.ResponseStatus;
 import com.pororoz.istock.domain.category.entity.Category;
 import com.pororoz.istock.domain.category.repository.CategoryRepository;
 import com.pororoz.istock.domain.outbound.dto.request.OutboundRequest;
-import com.pororoz.istock.domain.outbound.dto.response.OutboundConfirmResponse;
+import com.pororoz.istock.domain.outbound.dto.response.OutboundUpdateResponse;
 import com.pororoz.istock.domain.outbound.dto.response.OutboundResponse;
 import com.pororoz.istock.domain.product.entity.Product;
 import com.pororoz.istock.domain.product.entity.ProductIo;
@@ -227,7 +227,7 @@ public class OutboundIntegrationTest extends IntegrationTest {
         ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
 
         // then
-        OutboundConfirmResponse response = OutboundConfirmResponse.builder()
+        OutboundUpdateResponse response = OutboundUpdateResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(productIoQuantity)
@@ -361,7 +361,7 @@ public class OutboundIntegrationTest extends IntegrationTest {
         ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
 
         // then
-        OutboundConfirmResponse response = OutboundConfirmResponse.builder()
+        OutboundUpdateResponse response = OutboundUpdateResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(productIoQuantity)

--- a/src/test/java/com/pororoz/istock/domain/outbound/controller/OutboundControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/controller/OutboundControllerTest.java
@@ -11,10 +11,10 @@ import com.pororoz.istock.ControllerTest;
 import com.pororoz.istock.common.utils.message.ResponseMessage;
 import com.pororoz.istock.common.utils.message.ResponseStatus;
 import com.pororoz.istock.domain.outbound.dto.request.OutboundRequest;
-import com.pororoz.istock.domain.outbound.dto.response.OutboundConfirmResponse;
+import com.pororoz.istock.domain.outbound.dto.response.OutboundUpdateResponse;
 import com.pororoz.istock.domain.outbound.dto.response.OutboundResponse;
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceRequest;
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceResponse;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceRequest;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceResponse;
 import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceRequest;
 import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceResponse;
 import com.pororoz.istock.domain.outbound.service.OutboundService;
@@ -134,19 +134,19 @@ class OutboundControllerTest extends ControllerTest {
       @DisplayName("제품 출고 확정을 요청하면 productIO와 출고된 productId, quantity를 반환한다.")
       void outboundConfirm() throws Exception {
         // given
-        OutboundConfirmServiceResponse serviceResponse = OutboundConfirmServiceResponse.builder()
+        OutboundUpdateServiceResponse serviceResponse = OutboundUpdateServiceResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(quantity)
             .build();
 
         // when
-        when(outboundService.outboundConfirm(any(OutboundConfirmServiceRequest.class)))
+        when(outboundService.outboundConfirm(any(OutboundUpdateServiceRequest.class)))
             .thenReturn(serviceResponse);
         ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
 
         // then
-        OutboundConfirmResponse response = OutboundConfirmResponse.builder()
+        OutboundUpdateResponse response = OutboundUpdateResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(quantity)
@@ -192,19 +192,19 @@ class OutboundControllerTest extends ControllerTest {
       @DisplayName("제품 출고 취소를 하면 200 OK값과 해당 productIo와 product에 대한 정보를 제공한다.")
       void cancelOutbound() throws Exception {
         // given
-        OutboundConfirmServiceResponse serviceResponse = OutboundConfirmServiceResponse.builder()
+        OutboundUpdateServiceResponse serviceResponse = OutboundUpdateServiceResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(quantity)
             .build();
 
         // when
-        when(outboundService.outboundCancel(any(OutboundConfirmServiceRequest.class)))
+        when(outboundService.outboundCancel(any(OutboundUpdateServiceRequest.class)))
             .thenReturn(serviceResponse);
         ResultActions actions = getResultActions(url(productIoId), HttpMethod.POST);
 
         // then
-        OutboundConfirmResponse response = OutboundConfirmResponse.builder()
+        OutboundUpdateResponse response = OutboundUpdateResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(quantity)

--- a/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/service/OutboundServiceTest.java
@@ -6,8 +6,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceRequest;
-import com.pororoz.istock.domain.outbound.dto.service.OutboundConfirmServiceResponse;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceRequest;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceResponse;
 import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceRequest;
 import com.pororoz.istock.domain.outbound.dto.service.OutboundServiceResponse;
 import com.pororoz.istock.domain.outbound.exception.ChangeOutboundStatusException;
@@ -105,7 +105,7 @@ class OutboundServiceTest {
   @DisplayName("제품 출고 확정")
   class OutboundConfirm {
 
-    OutboundConfirmServiceRequest request = OutboundConfirmServiceRequest.builder()
+    OutboundUpdateServiceRequest request = OutboundUpdateServiceRequest.builder()
         .productIoId(productIoId)
         .build();
 
@@ -127,7 +127,7 @@ class OutboundServiceTest {
             .quantity(quantity)
             .product(product)
             .build();
-        OutboundConfirmServiceResponse response = OutboundConfirmServiceResponse.builder()
+        OutboundUpdateServiceResponse response = OutboundUpdateServiceResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(quantity)
@@ -135,7 +135,7 @@ class OutboundServiceTest {
 
         // when
         when(productIoRepository.findById(productIoId)).thenReturn(Optional.of(productIo));
-        OutboundConfirmServiceResponse result = outboundService.outboundConfirm(request);
+        OutboundUpdateServiceResponse result = outboundService.outboundConfirm(request);
 
         // then
         assertThat(result).usingRecursiveComparison().isEqualTo(response);
@@ -187,7 +187,7 @@ class OutboundServiceTest {
   @DisplayName("제품 출고 취소")
   class CancelOutbound {
 
-    OutboundConfirmServiceRequest request = OutboundConfirmServiceRequest.builder()
+    OutboundUpdateServiceRequest request = OutboundUpdateServiceRequest.builder()
         .productIoId(productIoId)
         .build();
 
@@ -209,7 +209,7 @@ class OutboundServiceTest {
             .quantity(quantity)
             .product(product)
             .build();
-        OutboundConfirmServiceResponse response = OutboundConfirmServiceResponse.builder()
+        OutboundUpdateServiceResponse response = OutboundUpdateServiceResponse.builder()
             .productIoId(productIoId)
             .productId(productId)
             .quantity(quantity)
@@ -218,7 +218,7 @@ class OutboundServiceTest {
         // when
         when(productIoRepository.findById(anyLong())).thenReturn(Optional.of(productIo));
         when(productRepository.findById(anyLong())).thenReturn(Optional.of(product));
-        OutboundConfirmServiceResponse result = outboundService.outboundCancel(request);
+        OutboundUpdateServiceResponse result = outboundService.outboundCancel(request);
 
         // then
         assertThat(result).usingRecursiveComparison().isEqualTo(response);


### PR DESCRIPTION
## 개요

- 제품 출고 DTO 네이밍 변경

## 세부 내용

- 제품 출고 확정 및 취소에서 사용하는 DTO 네이밍을 `OutboundConfirm*`에서 `OutboundUpdate*`로 변경

## 관련 이슈

- #112 