### PR TITLE
[Feature] Part io 조회 API

### DIFF
--- a/src/main/java/com/pororoz/istock/common/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/pororoz/istock/common/configuration/SecurityConfiguration.java
@@ -59,6 +59,7 @@ public class SecurityConfiguration {
         .requestMatchers("/v*/purchase/**").authenticated()
         .requestMatchers("/v*/outbounds/**").authenticated()
         .requestMatchers("/v*/product-io/**").authenticated()
+        .requestMatchers("/v*/part-io/**").authenticated()
         .anyRequest().hasRole("ADMIN")
     );
 

--- a/src/main/java/com/pororoz/istock/common/utils/message/ResponseMessage.java
+++ b/src/main/java/com/pororoz/istock/common/utils/message/ResponseMessage.java
@@ -37,6 +37,7 @@ public class ResponseMessage {
   public static final String OUTBOUND_CONFIRM = "제품 출고 확정";
   public static final String OUTBOUND_CANCEL = "제품 출고 취소";
   public static final String FIND_PRODUCT_IO = "제품 IO 조회";
+    public static final String FIND_PART_IO = "부품 IO 조회";
 
   public static final String UPLOAD_CSV = "CSV 업로드";
   private ResponseMessage() {

--- a/src/main/java/com/pororoz/istock/domain/part/controller/PartIoController.java
+++ b/src/main/java/com/pororoz/istock/domain/part/controller/PartIoController.java
@@ -1,0 +1,58 @@
+package com.pororoz.istock.domain.part.controller;
+
+import com.pororoz.istock.common.dto.PageResponse;
+import com.pororoz.istock.common.dto.ResultDTO;
+import com.pororoz.istock.common.swagger.exception.AccessForbiddenSwagger;
+import com.pororoz.istock.common.utils.message.ExceptionMessage;
+import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.part.dto.response.FindPartIoResponse;
+import com.pororoz.istock.domain.part.dto.service.FindPartIoServiceResponse;
+import com.pororoz.istock.domain.part.service.PartIoService;
+import com.pororoz.istock.domain.part.swagger.response.FindPartIoResponseSwagger;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.converters.models.PageableAsQueryParam;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@Tag(name = "PartIo", description = "PartIo API")
+@Validated
+@RestController
+@RequestMapping("/v1/part-io")
+@RequiredArgsConstructor
+public class PartIoController {
+
+  private final PartIoService partIoService;
+
+  @Operation(summary = "find part-io", description = "부품 IO 조회 API")
+  @ApiResponses({
+      @ApiResponse(responseCode = "200", description = ResponseMessage.FIND_PART_IO, content = {
+          @Content(schema = @Schema(implementation = FindPartIoResponseSwagger.class))}),
+      @ApiResponse(responseCode = "403", description = ExceptionMessage.FORBIDDEN, content = {
+          @Content(schema = @Schema(implementation = AccessForbiddenSwagger.class))})})
+  @PageableAsQueryParam
+  @GetMapping
+  public ResponseEntity<ResultDTO<PageResponse<FindPartIoResponse>>> findPartIO(
+      @Parameter(hidden = true) Pageable pageable,
+      @Schema(description = "부품 상태", example = "대기")
+      @RequestParam("status") String status) {
+    Page<FindPartIoResponse> partIoPage = partIoService.findPartIo(status, pageable)
+        .map(FindPartIoServiceResponse::toResponse);
+    PageResponse<FindPartIoResponse> response = new PageResponse<>(partIoPage);
+    return ResponseEntity.ok(
+        new ResultDTO<>(ResponseStatus.OK, ResponseMessage.FIND_PART_IO, response));
+  }
+}

--- a/src/main/java/com/pororoz/istock/domain/part/dto/response/FindPartIoResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/part/dto/response/FindPartIoResponse.java
@@ -1,0 +1,38 @@
+package com.pororoz.istock.domain.part.dto.response;
+
+import com.pororoz.istock.domain.part.entity.PartStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindPartIoResponse {
+
+  @Schema(description = "부품 IO 아이디", example = "1")
+  private Long partIoId;
+
+  @Schema(description = "부품 아이디", example = "1")
+  private Long partId;
+
+  @Schema(description = "수량",example = "10")
+  private long quantity;
+
+  @Schema(description = "부품 상태", example = "구매대기")
+  private PartStatus status;
+
+  @Schema(description = "생성일", example = "2023-01-16 13:01:23")
+  private String createdAt;
+
+  @Schema(description = "생성일", example = "2023-01-16 13:01:23")
+  private String updatedAt;
+
+  @Schema(description = "제품 IO 아이디", example = "1")
+  private Long productIoId;
+
+  @Schema(description = "품명", example = "PCB")
+  private String partName;
+
+  @Schema(description = "규격", example = "PCB-01-A")
+  private String spec;
+}

--- a/src/main/java/com/pororoz/istock/domain/part/dto/service/FindPartIoServiceResponse.java
+++ b/src/main/java/com/pororoz/istock/domain/part/dto/service/FindPartIoServiceResponse.java
@@ -1,0 +1,46 @@
+package com.pororoz.istock.domain.part.dto.service;
+
+import com.pororoz.istock.common.entity.TimeEntity;
+import com.pororoz.istock.domain.part.dto.response.FindPartIoResponse;
+import com.pororoz.istock.domain.part.entity.PartIo;
+import com.pororoz.istock.domain.part.entity.PartStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FindPartIoServiceResponse {
+
+  private Long partIoId;
+  private long quantity;
+  private PartStatus status;
+  private LocalDateTime createdAt;
+  private LocalDateTime updatedAt;
+  private Long productIoId;
+  private PartServiceResponse partServiceResponse;
+  public static FindPartIoServiceResponse of(PartIo partIo) {
+    return FindPartIoServiceResponse.builder()
+        .partIoId(partIo.getId())
+        .quantity(partIo.getQuantity())
+        .status(partIo.getStatus())
+        .createdAt(partIo.getCreatedAt())
+        .updatedAt(partIo.getUpdatedAt())
+        .productIoId(partIo.getProductIo() == null ? null : partIo.getProductIo().getId())
+        .partServiceResponse(PartServiceResponse.of(partIo.getPart()))
+        .build();
+  }
+
+  public FindPartIoResponse toResponse() {
+    return FindPartIoResponse.builder()
+        .partIoId(partIoId)
+        .quantity(quantity)
+        .status(status)
+        .productIoId(productIoId)
+        .createdAt(TimeEntity.formatTime(createdAt))
+        .updatedAt(TimeEntity.formatTime(updatedAt))
+        .partId(partServiceResponse.getPartId())
+        .partName(partServiceResponse.getPartName())
+        .spec(partServiceResponse.getSpec()).build();
+  }
+}

--- a/src/main/java/com/pororoz/istock/domain/part/repository/PartIoRepository.java
+++ b/src/main/java/com/pororoz/istock/domain/part/repository/PartIoRepository.java
@@ -3,6 +3,8 @@ package com.pororoz.istock.domain.part.repository;
 import com.pororoz.istock.domain.part.entity.PartIo;
 import com.pororoz.istock.domain.product.entity.ProductIo;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -13,4 +15,11 @@ public interface PartIoRepository extends JpaRepository<PartIo, Long> {
       + "left join fetch pi.part "
       + "where pi.productIo = :productIo")
   List<PartIo> findByProductIoWithPart(@Param("productIo") ProductIo productIo);
-}
+
+  @Query(value = "select p from PartIo p "
+      + "left join fetch p.part "
+      + "where cast(p.status as string) like %:status%"
+      , countQuery = "select p from PartIo p "
+      + "where cast(p.status as string) like %:status%")
+  Page<PartIo> findByStatusContainingWithPart(@Param("status") String status,
+      Pageable pageable);}

--- a/src/main/java/com/pororoz/istock/domain/part/service/PartIoService.java
+++ b/src/main/java/com/pororoz/istock/domain/part/service/PartIoService.java
@@ -1,0 +1,25 @@
+package com.pororoz.istock.domain.part.service;
+
+import com.pororoz.istock.domain.part.dto.service.FindPartIoServiceResponse;
+import com.pororoz.istock.domain.part.entity.PartIo;
+import com.pororoz.istock.domain.part.repository.PartIoRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class PartIoService {
+
+  private final PartIoRepository partIoRepository;
+
+  @Transactional(readOnly = true)
+  public Page<FindPartIoServiceResponse> findPartIo(String status, Pageable pageable) {
+    Page<PartIo> partIoPage = partIoRepository.findByStatusContainingWithPart(
+        status, pageable);
+    return partIoPage.map(FindPartIoServiceResponse::of);
+  }
+}

--- a/src/main/java/com/pororoz/istock/domain/part/swagger/response/FindPartIoResponseSwagger.java
+++ b/src/main/java/com/pororoz/istock/domain/part/swagger/response/FindPartIoResponseSwagger.java
@@ -1,0 +1,19 @@
+package com.pororoz.istock.domain.part.swagger.response;
+
+import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.part.dto.response.PartResponse;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class FindPartIoResponseSwagger {
+
+  @Schema(description = "Result Code", example = ResponseStatus.OK)
+  private String status;
+
+  @Schema(description = "Message", example = ResponseMessage.FIND_PART_IO)
+  private String message;
+
+  private PartResponse data;
+}

--- a/src/test/java/com/pororoz/istock/domain/part/PartIoIntegrationTest.java
+++ b/src/test/java/com/pororoz/istock/domain/part/PartIoIntegrationTest.java
@@ -1,0 +1,125 @@
+package com.pororoz.istock.domain.part;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pororoz.istock.IntegrationTest;
+import com.pororoz.istock.common.dto.PageResponse;
+import com.pororoz.istock.common.entity.TimeEntity;
+import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.part.dto.response.FindPartIoResponse;
+import com.pororoz.istock.domain.part.entity.Part;
+import com.pororoz.istock.domain.part.entity.PartIo;
+import com.pororoz.istock.domain.part.entity.PartStatus;
+import com.pororoz.istock.domain.part.repository.PartIoRepository;
+import com.pororoz.istock.domain.part.repository.PartRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.web.servlet.ResultActions;
+
+public class PartIoIntegrationTest extends IntegrationTest {
+
+  @Autowired
+  PartRepository partRepository;
+
+  @Autowired
+  PartIoRepository partIoRepository;
+
+  Part part;
+
+  @BeforeEach
+  void setUp() {
+    part = partRepository.save(Part.builder()
+        .partName("name").spec("spec")
+        .build());
+  }
+
+  @Nested
+  @DisplayName("GET /api/v1/part-io?page={}&size={}&status={} - 부품 IO 조회")
+  class FindPartIo {
+
+    String getUri(int page, int size, String status) {
+      return "/v1/part-io?page=" + page + "&size=" + size + "&status=" + status;
+    }
+
+    @Nested
+    @DisplayName("성공 케이스")
+    class SuccessCase {
+
+      @Test
+      @WithMockUser
+      @DisplayName("상태에 '완료'가 포함된 부품의 2페이지를 조회한다.")
+      void findPartIoConfirm() throws Exception {
+        // given
+        int page = 1, size = 1;
+        String uri = getUri(page, size, "완료");
+
+        PartIo partIo1 = partIoRepository.save(PartIo.builder()
+            .status(PartStatus.생산완료)
+            .quantity(10)
+            .part(part)
+            .build());
+        PartIo partIo2 = partIoRepository.save(PartIo.builder()
+            .status(PartStatus.입고완료)
+            .quantity(10)
+            .part(part)
+            .build());
+
+        FindPartIoResponse findPartIoResponse = FindPartIoResponse.builder()
+            .partIoId(partIo2.getId())
+            .quantity(partIo2.getQuantity())
+            .status(partIo2.getStatus())
+            .createdAt(TimeEntity.formatTime(partIo2.getCreatedAt()))
+            .updatedAt(TimeEntity.formatTime(partIo2.getUpdatedAt()))
+            .partId(partIo2.getPart().getId())
+            .partName(partIo2.getPart().getPartName())
+            .spec(partIo2.getPart().getSpec())
+            .build();
+
+        PageResponse<FindPartIoResponse> response = new PageResponse<>(
+            new PageImpl<>(List.of(findPartIoResponse), PageRequest.of(page, size), 2)
+        );
+
+        // when
+        ResultActions actions = getResultActions(uri, HttpMethod.GET);
+
+        // then
+        actions.andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+            .andExpect(jsonPath("$.message").value(ResponseMessage.FIND_PART_IO))
+            .andExpect(jsonPath("$.data", equalTo(asParsedJson(response))))
+            .andDo(print());
+      }
+
+      @Nested
+      @DisplayName("실패 케이스")
+      class FailCase {
+
+        @Test
+        @DisplayName("로그인하지 않은 유저는 접근할 수 없다.")
+        void cannotAccessAnonymous() throws Exception {
+          //given
+          int page = 1, size = 1;
+          String uri = getUri(page, size, "완료");
+
+          //when
+          ResultActions actions = getResultActions(uri, HttpMethod.GET);
+
+          //then
+          actions.andExpect(status().isForbidden());
+        }
+      }
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/part/controller/PartIoControllerTest.java
+++ b/src/test/java/com/pororoz/istock/domain/part/controller/PartIoControllerTest.java
@@ -1,0 +1,94 @@
+package com.pororoz.istock.domain.part.controller;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.pororoz.istock.ControllerTest;
+import com.pororoz.istock.common.dto.PageResponse;
+import com.pororoz.istock.common.entity.TimeEntity;
+import com.pororoz.istock.common.utils.message.ResponseMessage;
+import com.pororoz.istock.common.utils.message.ResponseStatus;
+import com.pororoz.istock.domain.part.dto.response.FindPartIoResponse;
+import com.pororoz.istock.domain.part.dto.service.FindPartIoServiceResponse;
+import com.pororoz.istock.domain.part.dto.service.PartServiceResponse;
+import com.pororoz.istock.domain.part.entity.PartStatus;
+import com.pororoz.istock.domain.part.service.PartIoService;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpMethod;
+import org.springframework.test.web.servlet.ResultActions;
+
+
+@WebMvcTest(value = PartIoController.class, excludeAutoConfiguration = {
+    SecurityAutoConfiguration.class})
+class PartIoControllerTest extends ControllerTest {
+
+  @MockBean
+  PartIoService partIoService;
+
+  String getUri(int page, int size, String status) {
+    return "/v1/part-io?page=" + page + "&size=" + size + "&status=" + status;
+  }
+
+  LocalDateTime now = LocalDateTime.now();
+
+  @Nested
+  @DisplayName("partIo 조회")
+  class FindPartIo {
+
+    @Test
+    @DisplayName("'대기'를 입력받아 partIo를 페이지네이션하여 조회한다.")
+    void findPartIo() throws Exception {
+      // given
+      int page = 1;
+      int size = 3;
+      String status = "대기";
+      String uri = getUri(page, size, status);
+      FindPartIoServiceResponse serviceResponse = FindPartIoServiceResponse.builder()
+          .partIoId(1L).quantity(10)
+          .status(PartStatus.구매대기)
+          .createdAt(now).updatedAt(now)
+          .partServiceResponse(PartServiceResponse.builder()
+              .partName("name").spec("spec")
+              .build())
+          .build();
+      PageImpl<FindPartIoServiceResponse> partIoPage = new PageImpl<>(
+          List.of(serviceResponse), PageRequest.of(page, size), 4);
+
+      // when
+      when(partIoService.findPartIo(eq(status), any(Pageable.class)))
+          .thenReturn(partIoPage);
+      ResultActions actions = getResultActions(uri, HttpMethod.GET);
+
+      // then
+      FindPartIoResponse findPartIoResponse = FindPartIoResponse.builder()
+          .partIoId(1L).quantity(10)
+          .status(PartStatus.구매대기)
+          .createdAt(TimeEntity.formatTime(now))
+          .updatedAt(TimeEntity.formatTime(now))
+          .partName("name")
+          .spec("spec").build();
+      PageResponse<FindPartIoResponse> response = new PageResponse<>(
+          new PageImpl<>(List.of(findPartIoResponse), PageRequest.of(page, size), 4));
+      actions.andExpect(status().isOk())
+          .andExpect(jsonPath("$.status").value(ResponseStatus.OK))
+          .andExpect(jsonPath("$.message").value(ResponseMessage.FIND_PART_IO))
+          .andExpect(jsonPath("$.data", equalTo(asParsedJson(response))))
+          .andDo(print());
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/part/repository/PartIoRepositoryTest.java
+++ b/src/test/java/com/pororoz/istock/domain/part/repository/PartIoRepositoryTest.java
@@ -1,0 +1,72 @@
+package com.pororoz.istock.domain.part.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.pororoz.istock.RepositoryTest;
+import com.pororoz.istock.domain.part.entity.Part;
+import com.pororoz.istock.domain.part.entity.PartIo;
+import com.pororoz.istock.domain.part.entity.PartStatus;
+import com.pororoz.istock.domain.product.entity.ProductIo;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public class PartIoRepositoryTest extends RepositoryTest {
+
+  @Autowired
+  PartIoRepository partIoRepository;
+
+  Part part;
+
+  @BeforeEach
+  void setUp() {
+    part = em.persist(Part.builder()
+        .partName("name")
+        .spec("spec").build());
+    em.flush();
+    em.clear();
+  }
+
+  @Nested
+  class FindByStatusContaining {
+
+    @Test
+    @DisplayName("status의 일부를 포함하는 partIo를 조회한다.")
+    void findByStatusContainingWithPart() {
+      // given
+      PartIo partIo1 = em.persist(PartIo.builder()
+          .quantity(10)
+          .status(PartStatus.구매대기)
+          .part(part).build());
+      PartIo partIo2 = em.persist(PartIo.builder()
+          .quantity(10)
+          .status(PartStatus.생산대기)
+          .part(part).build());
+      PartIo partIo3 = em.persist(PartIo.builder()
+          .quantity(10)
+          .status(PartStatus.생산완료)
+          .part(part).build());
+      em.flush();
+      em.clear();
+
+
+      // when
+      Page<PartIo> partIoPage = partIoRepository.findByStatusContainingWithPart(
+          "대기", Pageable.unpaged());
+
+      // then
+      assertThat(partIoPage.getTotalPages()).isEqualTo(1);
+      assertThat(partIoPage.getTotalElements()).isEqualTo(2);
+
+      List<PartIo> content = partIoPage.getContent();
+      List<PartIo> expected = List.of(partIo1, partIo2);
+      assertThat(content).usingRecursiveComparison()
+          .isEqualTo(expected);
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/part/service/PartIoServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/part/service/PartIoServiceTest.java
@@ -1,0 +1,75 @@
+package com.pororoz.istock.domain.part.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import com.pororoz.istock.domain.part.dto.service.FindPartIoServiceResponse;
+import com.pororoz.istock.domain.part.dto.service.PartServiceResponse;
+import com.pororoz.istock.domain.part.entity.Part;
+import com.pororoz.istock.domain.part.entity.PartIo;
+import com.pororoz.istock.domain.part.entity.PartStatus;
+import com.pororoz.istock.domain.part.repository.PartIoRepository;
+import com.pororoz.istock.domain.product.entity.ProductIo;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+@ExtendWith(MockitoExtension.class)
+public class PartIoServiceTest {
+
+  @InjectMocks
+  PartIoService partIoService;
+
+  @Mock
+  PartIoRepository partIoRepository;
+
+  @Nested
+  @DisplayName("partIo 조회")
+  class FindPartIo {
+
+    Part part = Part.builder().id(1L).build();
+
+    ProductIo productIo = ProductIo.builder().id(1L).build();
+
+    @Test
+    @DisplayName("'구매대기'의 partIo를 페이지네이션하여 조회한다.")
+    void findPartIo() {
+      // given
+      PageRequest pageRequest = PageRequest.of(0, 5);
+      PartIo partIo = PartIo.builder()
+          .id(1L).quantity(1)
+          .status(PartStatus.구매대기).part(part).productIo(productIo)
+          .build();
+
+      // when
+      when(partIoRepository.findByStatusContainingWithPart(eq("구매대기"), any(Pageable.class)))
+          .thenReturn(new PageImpl<>(List.of(partIo), pageRequest, 1L));
+      Page<FindPartIoServiceResponse> partIoPage = partIoService.findPartIo("구매대기",
+          pageRequest);
+
+      //then
+      FindPartIoServiceResponse serviceResponse = FindPartIoServiceResponse.builder()
+          .partIoId(partIo.getId())
+          .quantity(partIo.getQuantity())
+          .status(partIo.getStatus())
+          .productIoId(partIo.getProductIo().getId())
+          .partServiceResponse(PartServiceResponse.of(part))
+          .build();
+      assertThat(partIoPage.getTotalPages()).isEqualTo(1);
+      assertThat(partIoPage.getTotalElements()).isEqualTo(1);
+      assertThat(partIoPage.getContent()).usingRecursiveComparison()
+          .isEqualTo(List.of(serviceResponse));
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/part/service/PartIoServiceTest.java
+++ b/src/test/java/com/pororoz/istock/domain/part/service/PartIoServiceTest.java
@@ -58,7 +58,7 @@ public class PartIoServiceTest {
       Page<FindPartIoServiceResponse> partIoPage = partIoService.findPartIo("구매대기",
           pageRequest);
 
-      //then
+      // then
       FindPartIoServiceResponse serviceResponse = FindPartIoServiceResponse.builder()
           .partIoId(partIo.getId())
           .quantity(partIo.getQuantity())


### PR DESCRIPTION
## 개요
- Part의 생산/출고 기록 및 상태를 조회하는 기능
## 세부 내용
<html>
<body>
<!--StartFragment--><ul>
<li>
<p><strong>query</strong></p>
<ul>
<li>다른 GET 요청과 마찬가지로 page, size 패러미터를 쿼리스트링으로 입력받을 수 있음</li>
<li>다른 GET 요청과 마찬가지로 각 항목에 대해서 쿼리스트링으로 filtering을 할 수 있음</li>
<li><strong>(긴급하지 않음)</strong> <code>status</code> 컬럼의 경우 <code>구매대기</code> <code>구매완료</code> <code>구매취소</code> <code>생산대기</code> <code>생산완료</code> <code>생산취소</code> 의 상태를 가질 수 있는데, 직접적인 조회 외에도 <code>대기</code> <code>취소</code> <code>완료</code> 와 같은 키워드로도 검색이 가능해야 함. <em>(아마 where 조건문에 wildcard <code>*</code> 로 검색하도록 구현해 두었다면 이미 될 것 같긴 하지만…)</em></li>
</ul>


GET | /api/v1/part-io?page={}&size={}&status={}
-- | --



</li>
<li>
<p><strong>response</strong></p>
<ul>
<li>하기 응답 항목 중 <code>2순위</code>는 준필수 항목으로 기능적으로 반드시 필요하지는 않지만 사용성을 위해서 있다면 좋은 항목입니다. (별도의 GET 요청으로 partId를 통해 가져올 수도 있으니 MVP에는 포함되지 않습니다.)</li>
</ul>
<pre><code class="language-json">{
	status: &quot;OK&quot;,
	message: &quot;부품 IO 조회&quot;,
	data:{
		totalPages: 20,
		totalElements: 100,
		currentSize: 5,
		first: true,
		last: false,
		contents: {
			[
				{
					partIoId: 1
					partId: 45
					quantity: 100,
					status: &quot;구매대기&quot;,
					createdAt:&quot;2023-01-16 13:01:23&quot;
					updatedAt:&quot;2023-01-16 13:01:23&quot;
					productIoId: 12 // 있는 경우(일괄구매)만 표기, 없으면 null(undefined나 0 따위의 값으로 변경될 수 있음) 리턴
					partName: &quot;PCB&quot;, // 2순위, Join 필요
					partNumber: &quot;PCB-01-A&quot;, // 2순위, Join 필요
				},
				...
			],
		}
	}
}
</code></pre>
</li>
</ul>
<!--EndFragment-->
</body>
</html>

## 공유

- 고민과 질문
partNumber는 존재하지 않으므로 spec으로 변경하였음

## 관련 이슈
- #114 