### PR TITLE
[Feature] 구매 및 출고, 업데이트 시 잠금 설정

### DIFF
--- a/src/main/java/com/pororoz/istock/domain/bom/entity/Bom.java
+++ b/src/main/java/com/pororoz/istock/domain/bom/entity/Bom.java
@@ -16,6 +16,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -68,6 +69,9 @@ public class Bom extends TimeEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "sub_assy_id")
   private Product subAssy;
+
+  @Version
+  private long version;
 
   @Builder
   public Bom(Long id, String locationNumber, String codeNumber, long quantity, String memo,

--- a/src/main/java/com/pororoz/istock/domain/part/entity/Part.java
+++ b/src/main/java/com/pororoz/istock/domain/part/entity/Part.java
@@ -10,6 +10,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -54,6 +55,9 @@ public class Part extends TimeEntity {
   @Builder.Default
   @Column(columnDefinition = "INT(11) UNSIGNED default 0")
   private long stock = 0;
+
+  @Version
+  private Long version;
 
   public void update(UpdatePartServiceRequest request) {
     this.partName = request.getPartName();

--- a/src/main/java/com/pororoz/istock/domain/part/entity/PartIo.java
+++ b/src/main/java/com/pororoz/istock/domain/part/entity/PartIo.java
@@ -15,6 +15,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Builder;
@@ -47,6 +48,9 @@ public class PartIo extends TimeEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "product_io_id")
   private ProductIo productIo;
+
+  @Version
+  private Long version;
 
   @Builder
   public PartIo(Long id, long quantity, PartStatus status, Part part, ProductIo productIo) {

--- a/src/main/java/com/pororoz/istock/domain/product/entity/Product.java
+++ b/src/main/java/com/pororoz/istock/domain/product/entity/Product.java
@@ -13,6 +13,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PositiveOrZero;
 import jakarta.validation.constraints.Size;
@@ -64,6 +65,9 @@ public class Product extends TimeEntity {
   @OneToMany(mappedBy = "product", fetch = FetchType.LAZY)
   @Builder.Default
   private List<Bom> boms = new ArrayList<>();
+
+  @Version
+  private Long version;
 
   public void update(UpdateProductServiceRequest request, Category category) {
     this.productName = request.getProductName();

--- a/src/main/java/com/pororoz/istock/domain/product/entity/ProductIo.java
+++ b/src/main/java/com/pororoz/istock/domain/product/entity/ProductIo.java
@@ -17,6 +17,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Version;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import java.util.ArrayList;
@@ -57,6 +58,9 @@ public class ProductIo extends TimeEntity {
 
   @OneToMany(mappedBy = "superIo", fetch = FetchType.LAZY)
   private List<ProductIo> subAssyIoList;
+
+  @Version
+  private Long version;
 
   @Builder
   public ProductIo(Long id, long quantity, ProductStatus status, Product product, ProductIo superIo,

--- a/src/test/java/com/pororoz/istock/domain/outbound/OutboundLockTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/OutboundLockTest.java
@@ -129,12 +129,15 @@ public class OutboundLockTest {
           OutboundUpdateServiceRequest.builder().productIoId(1L).build()));
       Future<?> future2 = executorService.submit(() -> outboundService.outboundCancel(
           OutboundUpdateServiceRequest.builder().productIoId(1L).build()));
+      Future<?> future3 = executorService.submit(() -> outboundService.outboundConfirm(
+          OutboundUpdateServiceRequest.builder().productIoId(2L).build()));
       Exception result = new Exception();
 
       // when
       try {
         future1.get();
         future2.get();
+        future3.get();
       } catch (ExecutionException e) {
         result = (Exception) e.getCause();
       }

--- a/src/test/java/com/pororoz/istock/domain/outbound/OutboundLockTest.java
+++ b/src/test/java/com/pororoz/istock/domain/outbound/OutboundLockTest.java
@@ -1,0 +1,147 @@
+package com.pororoz.istock.domain.outbound;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pororoz.istock.common.service.DatabaseCleanup;
+import com.pororoz.istock.domain.bom.repository.BomRepository;
+import com.pororoz.istock.domain.category.entity.Category;
+import com.pororoz.istock.domain.category.repository.CategoryRepository;
+import com.pororoz.istock.domain.outbound.dto.service.OutboundUpdateServiceRequest;
+import com.pororoz.istock.domain.outbound.service.OutboundService;
+import com.pororoz.istock.domain.part.repository.PartIoRepository;
+import com.pororoz.istock.domain.part.repository.PartRepository;
+import com.pororoz.istock.domain.product.entity.Product;
+import com.pororoz.istock.domain.product.entity.ProductIo;
+import com.pororoz.istock.domain.product.entity.ProductStatus;
+import com.pororoz.istock.domain.product.repository.ProductIoRepository;
+import com.pororoz.istock.domain.product.repository.ProductRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+@SpringBootTest
+public class OutboundLockTest {
+
+  @Autowired
+  OutboundService outboundService;
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  ProductRepository productRepository;
+
+  @Autowired
+  PartRepository partRepository;
+
+  @Autowired
+  BomRepository bomRepository;
+
+  @Autowired
+  PartIoRepository partIoRepository;
+
+  @Autowired
+  ProductIoRepository productIoRepository;
+
+  @Autowired
+  DatabaseCleanup databaseCleanup;
+
+  @BeforeEach
+  void setUp() {
+    //product 저장
+    Category category = categoryRepository.save(Category.builder().categoryName("카테고리").build());
+    List<Product> products = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Product product = Product.builder()
+          .productName("p" + i)
+          .productNumber("p" + i)
+          .stock((int) (Math.random() * 100) + 1)
+          .category(category)
+          .codeNumber(String.valueOf(2 + i))
+          .build();
+
+      products.add(product);
+    }
+    productRepository.saveAll(products);
+
+    //productIo 저장
+    ProductIo productIo = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.출고대기)
+        .product(products.get(0))
+        .superIo(null)
+        .build();
+    productIoRepository.save(productIo);
+
+    ProductIo productIo1 = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.출고대기)
+        .product(products.get(0))
+        .superIo(productIo)
+        .build();
+    productIoRepository.save(productIo1);
+
+    ProductIo productIo2 = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.출고대기)
+        .product(products.get(9))
+        .superIo(productIo)
+        .build();
+    productIoRepository.save(productIo2);
+
+    ProductIo productIo3 = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.출고대기)
+        .product(products.get(9))
+        .superIo(productIo)
+        .build();
+    productIoRepository.save(productIo3);
+  }
+
+  @AfterEach
+  void afterEach() {
+    databaseCleanup.execute();
+  }
+
+  @Nested
+  @DisplayName("낙관적 락 테스트")
+  class LockingTest {
+    @Test
+    @DisplayName("출고 확정 및 취소가 겹칠 때 낙관적 락 테스트")
+    void purchaseConfilct() throws InterruptedException {
+      // given
+      // 스레드 개수 2개
+      int numberOfThreads = 2;
+      ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+      Future<?> future1 = executorService.submit(() -> outboundService.outboundConfirm(
+          OutboundUpdateServiceRequest.builder().productIoId(1L).build()));
+      Future<?> future2 = executorService.submit(() -> outboundService.outboundCancel(
+          OutboundUpdateServiceRequest.builder().productIoId(1L).build()));
+      Exception result = new Exception();
+
+      // when
+      try {
+        future1.get();
+        future2.get();
+      } catch (ExecutionException e) {
+        result = (Exception) e.getCause();
+      }
+
+      // then
+      // 동시에 접근하면 Error 발생 => Transaction 때문에 입력 X
+      assertTrue(result instanceof OptimisticLockingFailureException);
+    }
+  }
+}

--- a/src/test/java/com/pororoz/istock/domain/production/ProductionIntegrationTest.java
+++ b/src/test/java/com/pororoz/istock/domain/production/ProductionIntegrationTest.java
@@ -269,7 +269,7 @@ public class ProductionIntegrationTest extends IntegrationTest {
     ProductIo subAssyIo2 = createProductIo(quantity3 * quantity1, subAssyStatus);
     assertThat(productIoRepository.findAll()).usingRecursiveComparison()
         .ignoringFields("createdAt", "updatedAt", "id", "product", "superIo", "partIoList",
-            "subAssyIoList")
+            "subAssyIoList", "version")
         .isEqualTo(List.of(productIo, subAssyIo1, subAssyIo2));
   }
 
@@ -278,7 +278,7 @@ public class ProductionIntegrationTest extends IntegrationTest {
     PartIo partIo2 = createPartIo(quantity3 * quantity1, status);
 
     assertThat(partIoRepository.findAll()).usingRecursiveComparison()
-        .ignoringFields("createdAt", "updatedAt", "id", "part", "productIo")
+        .ignoringFields("createdAt", "updatedAt", "id", "part", "productIo", "version")
         .isEqualTo(List.of(partIo1, partIo2));
   }
 

--- a/src/test/java/com/pororoz/istock/domain/purchase/PurchaseLockTest.java
+++ b/src/test/java/com/pororoz/istock/domain/purchase/PurchaseLockTest.java
@@ -180,8 +180,8 @@ public class PurchaseLockTest {
       ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
 
       Future<?> future1 = executorService.submit(() -> purchaseService.confirmPurchasePart(1L));
-      Future<?> future2 = executorService.submit(() -> purchaseService.confirmPurchasePart(1L));
-      Future<?> future3 = executorService.submit(() -> purchaseService.confirmPurchasePart(1L));
+      Future<?> future2 = executorService.submit(() -> purchaseService.confirmPurchasePart(2L));
+      Future<?> future3 = executorService.submit(() -> purchaseService.confirmPurchasePart(2L));
       Exception result = new Exception();
 
       // when

--- a/src/test/java/com/pororoz/istock/domain/purchase/PurchaseLockTest.java
+++ b/src/test/java/com/pororoz/istock/domain/purchase/PurchaseLockTest.java
@@ -1,0 +1,282 @@
+package com.pororoz.istock.domain.purchase;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pororoz.istock.common.service.DatabaseCleanup;
+import com.pororoz.istock.domain.bom.entity.Bom;
+import com.pororoz.istock.domain.bom.repository.BomRepository;
+import com.pororoz.istock.domain.category.entity.Category;
+import com.pororoz.istock.domain.category.repository.CategoryRepository;
+import com.pororoz.istock.domain.part.entity.Part;
+import com.pororoz.istock.domain.part.entity.PartIo;
+import com.pororoz.istock.domain.part.entity.PartStatus;
+import com.pororoz.istock.domain.part.repository.PartIoRepository;
+import com.pororoz.istock.domain.part.repository.PartRepository;
+import com.pororoz.istock.domain.product.entity.Product;
+import com.pororoz.istock.domain.product.entity.ProductIo;
+import com.pororoz.istock.domain.product.entity.ProductStatus;
+import com.pororoz.istock.domain.product.repository.ProductIoRepository;
+import com.pororoz.istock.domain.product.repository.ProductRepository;
+import com.pororoz.istock.domain.purchase.service.PurchaseService;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.OptimisticLockingFailureException;
+
+@SpringBootTest
+public class PurchaseLockTest {
+
+  @Autowired
+  PurchaseService purchaseService;
+
+  @Autowired
+  CategoryRepository categoryRepository;
+
+  @Autowired
+  ProductRepository productRepository;
+
+  @Autowired
+  PartRepository partRepository;
+
+  @Autowired
+  BomRepository bomRepository;
+
+  @Autowired
+  PartIoRepository partIoRepository;
+
+  @Autowired
+  ProductIoRepository productIoRepository;
+
+  @Autowired
+  DatabaseCleanup databaseCleanup;
+
+  @BeforeEach
+  void setUp() {
+    //product 저장
+    Category category = categoryRepository.save(Category.builder().categoryName("카테고리").build());
+    List<Product> products = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Product product = Product.builder()
+          .productName("p" + i)
+          .productNumber("p" + i)
+          .stock((int) (Math.random() * 100) + 1)
+          .category(category)
+          .codeNumber(String.valueOf(2 + i))
+          .build();
+
+      products.add(product);
+    }
+    productRepository.saveAll(products);
+
+    //part 저장
+    List<Part> parts = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Part part = Part.builder()
+          .partName("p" + i)
+          .spec("p" + i)
+          .build();
+
+      parts.add(part);
+    }
+    partRepository.saveAll(parts);
+
+    //일반 bom
+    for (int i = 0; i < 9; i++) {
+      Bom bom = Bom.builder()
+          .quantity(1)
+          .codeNumber("10")
+          .locationNumber("" + i + 100)
+          .part(parts.get((int) (Math.random() * 9)))
+          .product(products.get((int) (Math.random() * 9)))
+          .build();
+
+      bomRepository.save(bom);
+    }
+
+    //productIo 저장
+    ProductIo productIo = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.구매대기)
+        .product(products.get(0))
+        .superIo(null)
+        .build();
+    productIoRepository.save(productIo);
+
+    ProductIo productIo1 = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.외주생산대기)
+        .product(products.get(0))
+        .superIo(productIo)
+        .build();
+    productIoRepository.save(productIo1);
+
+    ProductIo productIo2 = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.외주생산대기)
+        .product(products.get(9))
+        .superIo(productIo)
+        .build();
+    productIoRepository.save(productIo2);
+
+    ProductIo productIo3 = ProductIo.builder()
+        .quantity(10)
+        .status(ProductStatus.외주생산대기)
+        .product(products.get(9))
+        .superIo(productIo)
+        .build();
+    productIoRepository.save(productIo3);
+
+    //partIo 저장
+    PartIo partIo = PartIo.builder()
+        .quantity(10)
+        .status(PartStatus.구매대기)
+        .part(parts.get(0))
+        .productIo(productIo)
+        .build();
+    partIoRepository.save(partIo);
+
+    PartIo partIo2 = PartIo.builder()
+        .quantity(10)
+        .status(PartStatus.구매대기)
+        .part(parts.get(0))
+        .productIo(productIo)
+        .build();
+    partIoRepository.save(partIo2);
+
+    PartIo partIo3 = PartIo.builder()
+        .quantity(10)
+        .status(PartStatus.구매대기)
+        .part(parts.get(1))
+        .productIo(productIo)
+        .build();
+    partIoRepository.save(partIo3);
+  }
+
+  @AfterEach
+  void afterEach() {
+    databaseCleanup.execute();
+  }
+
+  @Nested
+  @DisplayName("낙관적 락 테스트")
+  class LockingTest {
+
+    @Test
+    @DisplayName("파트 구매 확정 낙관적 락 테스트")
+    void purchasePart() throws InterruptedException {
+      // given
+      // 스레드 개수 3개
+      int numberOfThreads = 3;
+      ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+      Future<?> future1 = executorService.submit(() -> purchaseService.confirmPurchasePart(1L));
+      Future<?> future2 = executorService.submit(() -> purchaseService.confirmPurchasePart(1L));
+      Future<?> future3 = executorService.submit(() -> purchaseService.confirmPurchasePart(1L));
+      Exception result = new Exception();
+
+      // when
+      try {
+        future1.get();
+        future2.get();
+        future3.get();
+      } catch (ExecutionException e) {
+        result = (Exception) e.getCause();
+      }
+
+      // then
+      // 동시에 접근하면 Error 발생 => Transaction 때문에 입력 X
+      assertTrue(result instanceof OptimisticLockingFailureException);
+    }
+
+    @Test
+    @DisplayName("파트 구매 확정 및 취소가 겹칠 때 낙관적 락 테스트")
+    void purchaseConfilct() throws InterruptedException {
+      // given
+      // 스레드 개수 3개
+      int numberOfThreads = 2;
+      ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+      Future<?> future1 = executorService.submit(() -> purchaseService.confirmPurchasePart(1L));
+      Future<?> future2 = executorService.submit(() -> purchaseService.cancelPurchasePart(1L));
+      Exception result = new Exception();
+
+      // when
+      try {
+        future1.get();
+        future2.get();
+      } catch (ExecutionException e) {
+        result = (Exception) e.getCause();
+      }
+
+      // then
+      // 동시에 접근하면 Error 발생 => Transaction 때문에 입력 X
+      assertTrue(result instanceof OptimisticLockingFailureException);
+    }
+
+    @Test
+    @DisplayName("외주생산 확정 낙관적 락 테스트")
+    void purchaseSubAssy() throws InterruptedException {
+      // given
+      int numberOfThreads = 3;
+      ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+      Future<?> future1 = executorService.submit(
+          () -> purchaseService.confirmSubAssyOutsourcing(2L));
+      Future<?> future2 = executorService.submit(
+          () -> purchaseService.confirmSubAssyOutsourcing(3L));
+      Future<?> future3 = executorService.submit(
+          () -> purchaseService.confirmSubAssyOutsourcing(3L));
+      Exception result = new Exception();
+
+      // when
+      try {
+        future1.get();
+        future2.get();
+        future3.get();
+      } catch (ExecutionException e) {
+        result = (Exception) e.getCause();
+      }
+
+      // then
+      // 동시에 접근하면 Error 발생 => Transaction 때문에 입력 X
+      assertTrue(result instanceof OptimisticLockingFailureException);
+    }
+
+    @Test
+    @DisplayName("외주생산 확정 및 취소가 동시에 일어났을 때 낙관적 락 테스트")
+    void purchaseSubAssyConfilct() throws InterruptedException {
+      // given
+      // 스레드 개수 3개
+      int numberOfThreads = 3;
+      ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+
+      Future<?> future1 = executorService.submit(
+          () -> purchaseService.confirmSubAssyOutsourcing(2L));
+      Future<?> future2 = executorService.submit(
+          () -> purchaseService.cancelSubAssyOutsourcing(2L));
+      Exception result = new Exception();
+
+      // when
+      try {
+        future1.get();
+        future2.get();
+      } catch (ExecutionException e) {
+        result = (Exception) e.getCause();
+      }
+
+      // then
+      // 동시에 접근하면 Error 발생 => Transaction 때문에 입력 X
+      assertTrue(result instanceof OptimisticLockingFailureException);
+    }
+  }
+}


### PR DESCRIPTION
## 개요

- Optimistic Lock을 이용해 잠금을 설정해보자.

## 세부 내용

- Optimistic Lock은 데이터 갱신시 충돌이 발생하지 않을 것이라고 생각하고 잠금을 거는 것이다.
  - 기본적으로 충돌이 발생하지 않을 거라고 생각하기 때문에 DB 자체에 락을 걸지 않아 성능이 우수!!
  - 하지만 충돌이 발생하면 모든 수행을 롤백시킨다.
- PartIo나 ProductIo의 값에 대한 업데이트가 동시에 일어날 때 
- 구매 Purchase & 출고 Outbound에 관련된 Entity에 @Version 어노테이션을 이용해 Optimistic Lock 세팅
  - Product
  - Part
  - Bom
  - ProductIo
  - PartIo
 - 낙관적락 테스트 작성

## 관련 이슈

- #122 